### PR TITLE
Consistency in how to format types

### DIFF
--- a/spec/php-spec-draft.md
+++ b/spec/php-spec-draft.md
@@ -1723,7 +1723,7 @@ Boolean values `TRUE` and `FALSE` ([§§](#core-predefined-constants)), respecti
 this type and its values is unspecified.
 
 The library function `is_bool` (§xx) indicates if a given value has type
-bool.
+`bool`.
 
 ###The Integer Type
 
@@ -1755,7 +1755,7 @@ The constants `PHP_INT_SIZE` (§[[6.3](#core-predefined-constants)](#core-predef
 characteristics about type `int`.
 
 The library function `is_int` (§xx) indicates if a given value has type
-int.
+`int`.
 
 ###The Floating-Point Type
 


### PR DESCRIPTION
There seems to be missing a specification on when to write e.g. bool and when to write `bool`.
The PR only contains two obvious corrections. 
There are more in there to consider.
