### PR TITLE
Fixing byRef assignment example for consistancy

### DIFF
--- a/spec/php-spec-draft.md
+++ b/spec/php-spec-draft.md
@@ -970,7 +970,7 @@ more variables. For example, `$a = 123` and `$b =& $a`, and `$c = 'hi'`:
 </pre>
 
 After the byRef assignment, `$a` and `$b` now have an alias relationship.
-Next, let's observe what happens for `$b = &$c`:
+Next, let's observe what happens for `$b =& $c`:
 <pre>
 [VSlot $a *]-->[VStore Int 123]
 


### PR DESCRIPTION
All other examples of byRef assignments use `$b =& $c`, while this one here used `$b = &$c`. Using the same syntax everywhere is just clearer.
