### PR TITLE
Fixed occurrence of NULL that was outside of back-ticks.

### DIFF
--- a/spec/php-spec-draft.md
+++ b/spec/php-spec-draft.md
@@ -8583,7 +8583,7 @@ by value.
 
 This instance method gets the value of the dynamic property ([§§](#dynamic-members))
 designated by `$name`. If no such dynamic property currently exists,
-NULL is returned.
+`NULL` is returned.
 
 Typically, `__get` is called implicitly, when the `->` operator ([§§](#member-selection-operator))
 is used in a non-lvalue context and the named property is not visible.


### PR DESCRIPTION
Whenever the PHP value `NULL` is used elsewhere in the spec, it is surrounded by back-ticks. The lack of back-ticks here seems to be a minor inconsistency.
