### PR TITLE
include ?> closing tag in addition to the less-common ones

### DIFF
--- a/spec/04-basic-concepts.md
+++ b/spec/04-basic-concepts.md
@@ -34,6 +34,7 @@ Opening tags:
 - `<%`
 
 Closing tags:
+- `?>`
 - `</script>`
 - `%>`
 


### PR DESCRIPTION
I can't see why this was missing, other than oversight, so I added it.
