### PR TITLE
use a definition list instead of ad-hoc markup for definitions

### DIFF
--- a/spec/03-terms-and-definitions.md
+++ b/spec/03-terms-and-definitions.md
@@ -2,49 +2,62 @@
 For the purposes of this document, the following terms and definitions
 apply:
 
-**argument** – a value passed to a function, that is intended to
-map to a corresponding parameter.
+<dl>
+    <dt>argument</dt>
+    <dd>a value passed to a function, that is intended to map to a
+    corresponding parameter.</dd>
 
-**behavior** – external appearance or action.
+    <dt>behavior</dt>
+    <dd>external appearance or action.</dd>
 
-**behavior, implementation-defined** – behavior specific to an
-implementation, where that implementation must document that behavior.
+    <dt>behavior, implementation-defined</dt>
+    <dd>behavior specific to an implementation, where that implementation
+    must document that behavior.</dd>
 
-**behavior, undefined** – behavior which is not guaranteed to produce
-any specific result. Usually follows an erroneous program
-construct or data.
+    <dt>behavior, undefined</dt>
+    <dd>behavior which is not guaranteed to produce any specific result.
+    Usually follows an erroneous program construct or data.</dd>
 
-**behavior, unspecified** – behavior for which this specification
-provides no requirements.
+    <dt>behavior, unspecified</dt>
+    <dd>behavior for which this specification provides no requirements.</dd>
 
-**constraint** – restriction, either syntactic or semantic, on how
-language elements can be used.
+    <dt>constraint</dt>
+    <dd>restriction, either syntactic or semantic, on how language elements
+    can be used.</dd>
 
-**error, fatal** – a condition in which the engine cannot continue
-executing the script and must terminate.
+    <dt>error, fatal</dt>
+    <dd>a condition in which the engine cannot continue executing the script
+    and must terminate.</dd>
 
-**error, fatal, catchable** – a fatal error that can be caught by a
-user-defined handler.
+    <dt>error, fatal, catchable</dt>
+    <dd>a fatal error that can be caught by a user-defined handler.</dd>
 
-**error, non-fatal** – an error that is not a fatal error and allows for 
-the engine to continue execution.
+    <dt>error, non-fatal</dt>
+    <dd>an error that is not a fatal error and allows for  the engine to
+    continue execution.</dd>
 
-**lvalue** – an expression that designates a location that can store
-a value.
+    <dt>lvalue</dt>
+    <dd>an expression that designates a location that can store a value.</dd>
 
-**lvalue, modifiable** – an lvalue whose value can be changed.
+    <dt>lvalue, modifiable</dt>
+    <dd>an lvalue whose value can be changed.</dd>
 
-**lvalue, non-modifiable** – an lvalue whose value cannot be changed.
+    <dt>lvalue, non-modifiable</dt>
+    <dd>an lvalue whose value cannot be changed.</dd>
 
-**parameter** – a variable declared in the parameter list of a function
-that is intended to map to a corresponding argument in a call to that
-function.
+    <dt>parameter</dt>
+    <dd>a variable declared in the parameter list of a function that is
+    intended to map to a corresponding argument in a call to that
+    function.</dd>
 
-**PHP Run-Time Engine** – the software that executes a PHP program.
-Referred to as *the Engine* throughout this specification.
+    <dt>PHP Run-Time Engine</dt>
+    <dd>the software that executes a PHP program. Referred to as <em>the
+    Engine</em> throughout this specification.</dd>
 
-**value** – a primitive unit of data operated by the Engine having a type
-and potentially other content depending on the type.
+    <dt>value</dt>
+    <dd>a primitive unit of data operated by the Engine having a type
+    and potentially other content depending on the type.</dd>
+</dl>
 
 Other terms are defined throughout this specification, as needed, with
 the first usage being typeset *like this*.


### PR DESCRIPTION
At first, I was apprehensive about adding HTML to the spec doc, but then I noticed that the [basic concepts](https://github.com/php/php-langspec/blob/211703ae6a6e658bb0e911902f42923ac025b88b/spec/04-basic-concepts.md) page already has some `<pre>` HTML, and it really should up to the rendering code to decide how to display stuff like lists.
