### PR TITLE
use declarations - lower confusion traits vs. use declarations

### DIFF
--- a/spec/18-namespaces.md
+++ b/spec/18-namespaces.md
@@ -199,7 +199,7 @@ namespace NS2
   use \NS1\C, \NS1\I, \NS1\T;
   class D extends C implements I
   {
-      function foo(T $t){}
+      use T; // trait (and not a use declaration) 
   }
   $v = \NS1\CON1; // explicit namespace still needed for constants
   \NS1\f();   // explicit namespace still needed for functions


### PR DESCRIPTION
- use declaration inside a class is not allowed (or the text is wrong)
- added another example instead
