### PR TITLE
Markdown formatting fixes in grammar spec

### DIFF
--- a/spec/19-grammar.md
+++ b/spec/19-grammar.md
@@ -268,7 +268,7 @@ octal-digit
     \X  <i>hexadecimal-digit   hexadecimal-digit<sub>opt</sub></i>
 
   <i>heredoc-string-literal::</i>
-    <<<  <i>hd-start-identifier   new-line   hd-char-sequence<sub>opt</sub>  new-line hd-end-identifier</i>  ;<i><sub>opt</sub>   new-line</i>
+    &lt;&lt;&lt;  <i>hd-start-identifier   new-line   hd-char-sequence<sub>opt</sub>  new-line hd-end-identifier</i>  ;<i><sub>opt</sub>   new-line</i>
 
   <i>hd-start-identifier::</i>
     <i>name</i>
@@ -296,7 +296,7 @@ octal-digit
 
 
   <i>nowdoc-string-literal::</i>
-    <<<  '  <i>hd-start-identifier</i>  '  <i>new-line  hd-char-sequence<sub>opt</sub>   new-line hd-end-identifier</i>  ;<i><sub>opt</sub>   new-line</i>     
+    &lt;&lt;&lt;  '  <i>hd-start-identifier</i>  '  <i>new-line  hd-char-sequence<sub>opt</sub>   new-line hd-end-identifier</i>  ;<i><sub>opt</sub>   new-line</i>     
 </pre>
 
 ####The Null Literal
@@ -612,8 +612,8 @@ octal-digit
 <pre>
   <i>shift-expression:</i>
     <i>additive-expression</i>
-    <i>shift-expression</i>  <<  <i>additive-expression</i>
-    <i>shift-expression</i>  >>  <i>additive-expression</i>
+    <i>shift-expression</i>  &lt;&lt;  <i>additive-expression</i>
+    <i>shift-expression</i>  &gt;&gt;  <i>additive-expression</i>
 </pre>
 
 ####Relational Operators
@@ -621,10 +621,10 @@ octal-digit
 <pre>
   <i>relational-expression:</i>
     <i>shift-expression</i>
-    <i>relational-expression</i>  <   <i>shift-expression</i>
-    <i>relational-expression</i>  >   <i>shift-expression</i>
-    <i>relational-expression</i>  <=  <i>shift-expression</i>
-    <i>relational-expression</i>  >=  <i>shift-expression</i>
+    <i>relational-expression</i>  &lt;   <i>shift-expression</i>
+    <i>relational-expression</i>  &gt;   <i>shift-expression</i>
+    <i>relational-expression</i>  &lt;=  <i>shift-expression</i>
+    <i>relational-expression</i>  &gt;=  <i>shift-expression</i>
 </pre>
 
 ####Equality Operators
@@ -634,7 +634,7 @@ octal-digit
     <i>relational-expression</i>
     <i>equality-expression</i>  ==  <i>relational-expression</i>
     <i>equality-expression</i>  !=  <i>relational-expression</i>
-    <i>equality-expression</i>  <>  <i>relational-expression</i>
+    <i>equality-expression</i>  &lt;&gt;  <i>relational-expression</i>
     <i>equality-expression</i>  ===  <i>relational-expression</i>
     <i>equality-expression</i>  !==  <i>relational-expression</i>
 </pre>


### PR DESCRIPTION
Markdown formatting fixes for less than and greater than signs. Some symbols were missing because of the use of `<` and `>` in the html sections.
