### PR TITLE
Update array drawings

### DIFF
--- a/spec/04-basic-concepts.md
+++ b/spec/04-basic-concepts.md
@@ -1006,7 +1006,7 @@ possible outcome:
        +-----------------+           V                           |           |
        |                     [VStore int 1]                 +----+           |
        V                                                    |                V
-  [VStore Arr-D *]-->[HStore Array [VSlot 0 *] [VSlot 1 *]] | [VStore string 'hi']
+  [VStore Arr *]---->[HStore Array [VSlot 0 *] [VSlot 1 *]] | [VStore string 'hi']
                                             |           |   |
                                     +-------+           |   |
                                     |                   V   |
@@ -1027,7 +1027,7 @@ Here is the third possible outcome:
        +----------------+           V                           |           |
        |                     [VStore int 1]                  +--+           |
        V                                                     |              V
-   [VStore Arr-D *]-->[HStore Array [VSlot 0 *] [VSlot 1 *]] | [VStore string 'hi']
+   [VStore Arr *]---->[HStore Array [VSlot 0 *] [VSlot 1 *]] | [VStore string 'hi']
                                              |           |   |
                      [VStore int 123]&lt;-------+           |   |
                                                          V   |

--- a/spec/04-basic-concepts.md
+++ b/spec/04-basic-concepts.md
@@ -748,6 +748,7 @@ the value assignment `$b = $a`:
 [HStore Array [VSlot 0 *] [VSlot 'B' *]]                                        |
                        |             |                                          |
              +---------+   +---------+                                          |
+             |             |                                                    |
              V             V                                                    |
 [VStore int 10] [VStore object *]-->[HStore Point [VSlot $x *] [VSlot $y *]]&lt;---+
                                                             |            |
@@ -967,6 +968,7 @@ outcomes:
 [VSlot $b *]-->[VStore array *]            [VStore Arr *]&lt;---+
                              |                         |
       +----------------------+              +----------+
+      |                                     |
       V                                     V
   [HStore Array [VSlot 0 *] [VSlot 1 *]]  [HStore Array [VSlot 0 *] [VSlot 1 *]]
                          |           |       ^                   |           |
@@ -1000,7 +1002,9 @@ possible outcome:
                                                              |
 [VSlot $b *]-->[VStore array *]          [VStore array *]&lt;---+
                              |                         |
-                             V                         V
+    +------------------------+              +----------+
+    |                                       |
+    V                                       V
   [HStore Array [VSlot 0 *] [VSlot 1 *]]  [HStore Array [VSlot 0 *] [VSlot 1 *]]
                          |           |                           |           |
        +-----------------+           V                           |           |
@@ -1017,7 +1021,7 @@ possible outcome:
 
 Here is the third possible outcome:
 <pre>
-[VSlot $a *]---->[VStore array *-]---->[HStore Array [VSlot 0 *]]
+[VSlot $a *]--->[VStore array *]---->[HStore Array [VSlot 0 *]]
                                                             |
 [VSlot $b *]-->[VStore array *]           [VStore array *]&lt;---+
                              |                          |
@@ -1228,8 +1232,9 @@ Let us consider the result of `$b = clone $a`:
 [VSlot $a *]-->[VStore object *]-->[HStore Widget [VSlot $p1 *][VSlot $p2 *]]
                                                              |            |
 [VSlot $b *]-->[VStore object *]                             V            V
-                             |                  [VStore int 10] [VStore object *]
-     +-----------------------+                                                 |
+                              |                 [VStore int 10] [VStore object *]
+     +------------------------+                                                |
+     |                                                                         |
      V                                                                         |
    [HStore Widget [VSlot $p1 *] [VSlot $p2 *]]              +--->[HStore ...]&lt;-+
                              |             |                |


### PR DESCRIPTION
Corrected some arrows to start from the \* and explicitly end at the right object.
Deferred VStore should no longer be deferred after copying the HStore.
