### PR TITLE
Unify const-expression/constant-expression, arrays are allowed in constants since 5.6

### DIFF
--- a/spec/06-constants.md
+++ b/spec/06-constants.md
@@ -17,8 +17,9 @@ Specifically:
     value of the third argument passed to `define`.
 -   If `define` is able to define the given name, it returns `TRUE`;
     otherwise, it returns `FALSE`.
+-   `define` cannot create array constants.
 
-The constants can only hold a value of a [scalar type](05-types.md#scalar-types) or a [resource](05-types.md#resource-types).
+The constants can only hold a value of a [scalar type](05-types.md#scalar-types), an array or a [resource](05-types.md#resource-types).
 
 The library function `defined` (§xx) reports if a given name (specified as
 a string) is defined as a constant. The library function `constant` (§xx)

--- a/spec/07-variables.md
+++ b/spec/07-variables.md
@@ -136,10 +136,10 @@ $colors[] = "green";                // insert a new element
   <i>function-static-declaration:</i>
     static <i>variable-name</i> <i>function-static-initializer<sub>opt</sub></i> ;
   <i>function-static-initializer:</i>
-    = <i>const-expression</i>
+    = <i>constant-expression</i>
 </pre>
 
-*variable-name* is defined in ([§§](09-lexical-structure.md#names)), and *const-expression* is defined in
+*variable-name* is defined in ([§§](09-lexical-structure.md#names)), and *constant-expression* is defined in
 ([§§](10-expressions.md#constant-expressions)).
 
 **Constraints:**

--- a/spec/10-expressions.md
+++ b/spec/10-expressions.md
@@ -93,7 +93,7 @@ function, `$a` need not actually be incremented.
     <i>variable-name</i>
     <i>qualified-name</i>
     <i>literal</i>
-    <i>const-expression</i>
+    <i>constant-expression</i>
     <i>intrinsic</i>
     <i>anonymous-function-creation-expression</i>
     (  <i>expression</i>  )
@@ -101,7 +101,7 @@ function, `$a` need not actually be incremented.
 </pre>
 
 *variable-name* and *qualified-name* are defined in [§§](09-lexical-structure.md#names); *literal*
-is defined in [§§](09-lexical-structure.md#general-2); *const-expression* is defined in [§§](#constant-expressions);
+is defined in [§§](09-lexical-structure.md#general-2); *constant-expression* is defined in [§§](#constant-expressions);
 *intrinsic* is defined in [§§](#general-2);
 *anonymous-function-creation-expression* is defined in [§§](#anonymous-function-creation); and
 *expression* is defined in [§§](#script-inclusion-operators).
@@ -3008,9 +3008,6 @@ and relative path) still are considered the same file.
 <pre>
   <i>constant-expression:</i>
     <i>array-creation-expression</i>
-    <i>const-expression</i>
-
-  <i>const-expression:</i>
     <i>expression</i>
 </pre>
 
@@ -3026,13 +3023,10 @@ All of the *element-key* and *element-value* elements in
 
 **Semantics**
 
-A *const-expression* is the value of a c-constant. A *const-expression*
+A *constant-expression* is the value of a c-constant. A *constant-expression*
 is required in several contexts, such as in initializer values in a
 [*const-declaration*](14-classes.md#constants) and default initial values in a [function
 definition](13-functions.md#function-definitions).
-
-An initializer in a [*property-declaration*](14-classes.md#properties) is less restrictive
-than one in a *const-declaration*.
 
 
 

--- a/spec/13-functions.md
+++ b/spec/13-functions.md
@@ -66,10 +66,10 @@ A function is called via the function-call operator `()` ([§§](10-expressions.
     <i>qualified-name</i>
 
   <i>default-argument-specifier:</i>
-    =  <i>const-expression</i>
+    =  <i>constant-expression</i>
 </pre>
 
-*const-expression* is defined in [§§](10-expressions.md#constant-expressions). *qualified-name* is defined in
+*constant-expression* is defined in [§§](10-expressions.md#constant-expressions). *qualified-name* is defined in
 [§§](09-lexical-structure.md#names).
 
 **Constraints**

--- a/spec/14-classes.md
+++ b/spec/14-classes.md
@@ -370,10 +370,10 @@ Widget::__callStatic('sMethod', array(NULL, 1.234))
 
 <pre>
   <i>const-declaration:</i>
-    const  <i>name</i>  =  <i>const-expression</i>   ;
+    const  <i>name</i>  =  <i>constant-expression</i>   ;
 </pre>
 
-*name* is defined in ([§§](09-lexical-structure.md#names)). *const-expression* is defined in
+*name* is defined in ([§§](09-lexical-structure.md#names)). *constant-expression* is defined in
 ([§§](10-expressions.md#constant-expressions)).
 
 **Constraints:**

--- a/spec/19-grammar.md
+++ b/spec/19-grammar.md
@@ -338,7 +338,7 @@ octal-digit
     static <i>name</i>   <i>function-static-initializer<sub>opt</sub></i> ;
 
   <i>function-static-initializer:</i>
-    = <i>const-expression</i>
+    = <i>constant-expression</i>
 
   <i>global-declaration:</i>
     global <i>variable-name-list</i> ;
@@ -357,7 +357,7 @@ octal-digit
     <i>variable-name</i>
     <i>qualified-name</i>
     <i>literal</i>
-    <i>const-expression</i>
+    <i>constant-expression</i>
     <i>intrinsic</i>
     <i>anonymous-function-creation-expression</i>
     (  <i>expression</i>  )
@@ -757,9 +757,6 @@ octal-digit
 <pre>
   <i>constant-expression:</i>
     <i>array-creation-expression</i>
-    <i>const-expression</i>
-
-  <i>const-expression:</i>
     <i>expression</i>
 </pre>
 
@@ -1000,7 +997,7 @@ octal-digit
     <i>qualified-name</i>
 
   <i>default-argument-specifier:</i>
-    =  <i>const-expression</i>
+    =  <i>constant-expression</i>
 </pre>
 
 ###Classes
@@ -1032,7 +1029,7 @@ octal-digit
      <i>destructor-declaration</i>
 
   <i>const-declaration:</i>
-    const  <i>name</i>  =  <i>const-expression</i>   ;
+    const  <i>name</i>  =  <i>constant-expression</i>   ;
 
   <i>property-declaration:</i>
     <i>property-modifier   name   property-initializer<sub>opt</sub></i>  ;


### PR DESCRIPTION
Unfortunately [HHVM doesn't support them yet](https://github.com/facebook/hhvm/issues/4277). Maybe this'll motivate them to actually support it.
