### PR TITLE
Closure object metadata a bit different, but that's ok

### DIFF
--- a/tests/functions/anonymous_functions.php.expectf
+++ b/tests/functions/anonymous_functions.php.expectf
@@ -2,7 +2,7 @@
 --
 string(6) "object"
 --
-object(Closure)#1 (0) {
+object(Closure%S)#1 (0) {
 }
 --
 bool(true)
@@ -10,7 +10,7 @@ bool(true)
 Inside function >>{closure}<<
 Inside method >>{closure}<<
 ----------------- closure with 4 parameters ----------------------
-object(Closure)#2 (1) {
+object(Closure%S)#2 (1) {
   ["parameter"]=>
   array(5) {
     ["$p1"]=>
@@ -28,7 +28,7 @@ object(Closure)#2 (1) {
 --
 string(6) "object"
 --
-object(Closure)#2 (1) {
+object(Closure%S)#2 (1) {
   ["parameter"]=>
   array(5) {
     ["$p1"]=>
@@ -55,7 +55,7 @@ Result of calling doit using function double = 20
 string(6) "square"
 Result of calling doit using function square = 100
 -------
-object(Closure)#3 (1) {
+object(Closure%S)#3 (1) {
   ["parameter"]=>
   array(1) {
     ["$p"]=>
@@ -64,7 +64,7 @@ object(Closure)#3 (1) {
 }
 Result of calling doit using double closure = 10
 -------
-object(Closure)#3 (1) {
+object(Closure%S)#3 (1) {
   ["parameter"]=>
   array(1) {
     ["$p"]=>
@@ -82,7 +82,7 @@ $count = 2
 --
 string(6) "object"
 --
-object(Closure)#4 (3) {
+object(Closure%S)#4 (3) {
   ["static"]=>
   array(2) {
     ["count"]=>
@@ -118,7 +118,7 @@ $count = 2
 --
 string(6) "object"
 --
-object(Closure)#5 (1) {
+object(Closure%S)#5 (1) {
   ["this"]=>
   object(D)#3 (0) {
   }
@@ -131,7 +131,7 @@ Inside method >>D::{closure}<<
 --
 string(6) "object"
 --
-object(Closure)#5 (2) {
+object(Closure%S)#5 (2) {
   ["static"]=>
   array(2) {
     ["count"]=>


### PR DESCRIPTION
The metadata information for a Closure varies a bit differently from php-src and HHVM, but that shouldn't affect spec conformance.