### PR TITLE
Constant arrays (master)

### DIFF
--- a/spec/05-types.md
+++ b/spec/05-types.md
@@ -103,7 +103,7 @@ As to how the bytes in a string translate into characters is
 unspecified.
 
 Although a user of a string might choose to ascribe special semantics to
-bytes having the value `U+0000`, from PHP's perspective, such *null bytes*
+bytes having the value `\0`, from PHP's perspective, such *null bytes*
 have no special meaning. PHP does not assume strings contain any specific
 data or assign special values to any bytes or sequences. However, many
 library functions assume the strings they receive as arguments are UTF-8

--- a/spec/06-constants.md
+++ b/spec/06-constants.md
@@ -17,7 +17,6 @@ Specifically:
     value of the third argument passed to `define`.
 -   If `define` is able to define the given name, it returns `TRUE`;
     otherwise, it returns `FALSE`.
--   `define` cannot create array constants.
 
 The constants can only hold a value of a [scalar type](05-types.md#scalar-types), an array or a [resource](05-types.md#resource-types).
 

--- a/spec/10-expressions.md
+++ b/spec/10-expressions.md
@@ -1599,7 +1599,7 @@ are ignored. With a non-numeric string, the result has type `int` and
 value 0.
 
 For a unary `~` operator used with a string, the result is the string with each byte
-being bitwise complement of the correstopding byte of the source string.
+being bitwise complement of the corresponding byte of the source string.
 
 *Object Operands*
 
@@ -2272,6 +2272,11 @@ to that type.
 The result of this operator is the bitwise-AND of the two operands, and
 the type of that result is `int`.
 
+However, if both operands are strings, the result is the string composed of the sequence of bytes
+that are the result of bitwise AND operation performed on the bytes of the operand strings 
+in the matching poitions (`result[0] = s1[0] & s2[0]`, etc.).
+If one of the strings is longer than the other, it is cut to the length of the shorer one.
+
 This operator associates left-to-right.
 
 **Examples**
@@ -2308,6 +2313,11 @@ to that type.
 
 The result of this operator is the bitwise exclusive-OR of the two
 operands, and the type of that result is `int`.
+
+HHowever, if both operands are strings, the result is the string composed of the sequence of bytes
+that are the result of bitwise XOR operation performed on the bytes of the operand strings 
+in the matching poitions (`result[0] = s1[0] ^ s2[0]`, etc.).
+If one of the strings is longer than the other, it is cut to the length of the shorer one.
 
 This operator associates left-to-right.
 
@@ -2347,6 +2357,11 @@ to that type.
 
 The result of this operator is the bitwise inclusive-OR of the two
 operands, and the type of that result is `int`.
+
+However, if both operands are strings, the result is the string composed of the sequence of bytes
+that are the result of bitwise OR operation performed on the bytes of the operand strings 
+in the matching poitions (`result[0] = s1[0] | s2[0]`, etc.).
+If one of the strings is shorter than the other, it is extended with zero bytes. 
 
 This operator associates left-to-right.
 

--- a/spec/14-classes.md
+++ b/spec/14-classes.md
@@ -89,11 +89,20 @@ not be `parent`, `self`, or `static`.
 A concrete class must implement each of the methods from all the
 interfaces ([§§](15-interfaces.md#general)) specified in *class-interface-clause*.
 
-For each interface method, the corresponding concrete method must include similar arguments specified
-in the interface method: For each interface method argument, the corresponding concrete method argument
-must have the same type hint if provided (or none if not provided) and must include a default value if
-the interface method argument has a default. The argument names and default values may differ. The
-concrete method may include additional arguments provided each has a default value.
+For each interface method, the corresponding implementing method must be compatible with the interface method, including the following:
+- If the interface method is defined as [retuning byRef](13-functions.md#function-definitions), the implementing method should also return byRef.
+- If the interface method is variadic, the implementing method must also be variadic (see also below).
+- The number of required (i.e. having no defaults) arguments of the implementing methods can not be more than the number of required arguments of the interface method (adding non-optional arguments is not allowed).
+- The overall number of arguments for the implementing method should be at least the number of the arguments of the interface method (removing arguments is not allowed).
+- Each argument of the implementing method must be compatible with corresponding argument of the prototype method. 
+
+Compatible arguments are defined as follows:
+- Parameter names do not matter.
+- If the argument is optional (has default) in the interface, it should be optional in the implementation. However, implementation can provide a different default value.
+- byRef argument requires byRef implementation, and non-byRef argument can not have byRef implementation.
+- For no argument type, only declaration with no type is compatible.
+- For typed argument, only argument with the same type is compatible.
+- For variadic arguments, the definition of the variadic (last) argument should be compatible as per above. The implementation can define additional optional arguments before the variadic argument, but these arguments should be compatible with the variadic argument on the interface method.
 
 *qualified-name* in *class-interface-clause* must name an interface
 type.

--- a/spec/18-namespaces.md
+++ b/spec/18-namespaces.md
@@ -199,7 +199,7 @@ namespace NS2
   use \NS1\C, \NS1\I, \NS1\T;
   class D extends C implements I
   {
-    use T;
+    use T;  // trait (and not a namespace use declaration)
   }
   $v = \NS1\CON1; // explicit namespace still needed for constants
   \NS1\f();   // explicit namespace still needed for functions


### PR DESCRIPTION
This is a version of https://github.com/php/php-langspec/pull/106 for master. The difference is that it allows constant arrays in `define()`. Please merge the PHP-5.6 request before this one.