### PR TITLE
Update list() spec for PHP 7

### DIFF
--- a/spec/10-expressions.md
+++ b/spec/10-expressions.md
@@ -407,18 +407,20 @@ isset($v1, $v2, $v3);  // results in FALSE
 
 *list-intrinsic* must be used as the left-hand operand in a
 [*simple-assignment-expression*](#simple-assignment) of which the right-hand
-operand must be an expression that designates an array (called the *source
-array*).
+operand must be an expression that designates an array or object implementing
+the `ArrayAccess` interface (called the *source array*).
 
-Each *expression* in *expression-list-one-or-more* must designate a
-variable (called the *target variable*).
+Each *expression* in *list-or-variable* must designate a variable (called
+the *target variable*).
+
+At least on the elements of the *list-expression-list* must be non-empty.
 
 **Semantics**
 
-This intrinsic assigns zero or more elements of the source array to the
-target variables. On success, it returns a copy of the source array. If
-the source array is actually the value `NULL`, this is consider a failure,
-and the return value from `list` is undefined.
+This intrinsic assigns one or more elements of the source array to the
+target variables. On success, it returns a copy of the source array. If the
+source array is not an array or object implementing `ArrayAccess` no
+assignments are performed and the return value is `NULL`.
 
 All elements in the source array having keys of type `string` are ignored.
 The element having an `int` key of 0 is assigned to the first target
@@ -428,6 +430,8 @@ assigned. Any other array elements are ignored. If there are
 fewer source array elements having int keys than there are target
 variables, the unassigned target variables are set to `NULL` and
 a non-fatal error is produced.
+
+The assignments must occur in this order. 
 
 Any target variable may be a list, in which case, the corresponding
 element is expected to be an array.
@@ -448,6 +452,11 @@ list($min, $max, $avg) = array(0, 2 => 100, 4 => 67);
   // $min is 0, $max is NULL, $avg is 100
 list($min, list($max, $avg)) = [0, [1 => 67, 99, 0 => 100], 33];
   // $min is 0, $max is 100, $avg is 67
+
+list($arr[1], $arr[0]) = [0, 1];
+  // $arr is [1 => 0, 0 => 1], in this order
+list($arr2[], $arr2[]) = [0, 1];
+  // $arr2 is [0, 1]
 ```
 
 ####print

--- a/tests/expressions/primary_expressions/intrinsics_list.phpt
+++ b/tests/expressions/primary_expressions/intrinsics_list.phpt
@@ -1,5 +1,5 @@
 --TEST--
-PHP Spec test generated from ./expressions/primary_expressions/intrinsics_list.php
+list() intrinsic
 --FILE--
 <?php
 
@@ -97,7 +97,7 @@ print_r($v);
 echo "--------- test with non-numeric array -------------\n";
 
 $v = list($min, $max, $avg) = ["x" => 10, "a" => 20, "y" => 30];
-	// Undefined offset: 2, 1, 0
+	// Undefined offset: 0, 1, 2
 echo "\$min: $min, \$max: $max, \$avg: $avg\n";
 print_r($v);
 
@@ -129,7 +129,8 @@ $v = list($a[0], $a[2], $a[4]) = array(0, 100, 67);
 print_r($a);
 print_r($v);
 
-echo "--------- test with no variables -------------\n";
+// All of the following are invalid
+/*echo "--------- test with no variables -------------\n";
 
 $v = list() = array(0, 100, 67);
 print_r($v);
@@ -138,7 +139,7 @@ $v = list(,) = array(0, 100, 67);
 print_r($v);
 
 $v = list(,,) = array(0, 100, 67);
-print_r($v);
+print_r($v);*/
 --EXPECTF--
 --------- test with full and omitted LHS vars -------------
 $min: 0, $max: 100, $avg: 67
@@ -223,11 +224,11 @@ Array
 )
 --------- test with non-numeric array -------------
 
-Notice: Undefined %s: 2 in %s/expressions/primary_expressions/intrinsics_list.php on line 96
+Notice: Undefined %s: 0 in %s/expressions/primary_expressions/intrinsics_list.php on line 96
 
 Notice: Undefined %s: 1 in %s/expressions/primary_expressions/intrinsics_list.php on line 96
 
-Notice: Undefined %s: 0 in %s/expressions/primary_expressions/intrinsics_list.php on line 96
+Notice: Undefined %s: 2 in %s/expressions/primary_expressions/intrinsics_list.php on line 96
 $min: , $max: , $avg: 
 Array
 (
@@ -279,28 +280,9 @@ Array
 --------- test with target vars being array elements -------------
 Array
 (
-    [4] => 67
+    [0] => 0
     [2] => 100
-    [0] => 0
-)
-Array
-(
-    [0] => 0
-    [1] => 100
-    [2] => 67
-)
---------- test with no variables -------------
-Array
-(
-    [0] => 0
-    [1] => 100
-    [2] => 67
-)
-Array
-(
-    [0] => 0
-    [1] => 100
-    [2] => 67
+    [4] => 67
 )
 Array
 (


### PR DESCRIPTION
 * Empty lists are no longer allowed
 * Assignment must occur left to right
 * Explicitly mention that ArrayAccess is supported