### PR TITLE
switch cannot contain arbitrary statements

### DIFF
--- a/spec/11-statements.md
+++ b/spec/11-statements.md
@@ -81,6 +81,10 @@ while (condition)
 **Syntax**
 
 <pre>
+  <i>labeled-statement-list:</i>
+    <i>labeled-statement</i>
+    <i>labeled-statement-list labeled-statement</i>
+    
   <i>labeled-statement:</i>
     <i>named-label</i>
     <i>case-label</i>
@@ -286,18 +290,17 @@ else  // this else does go with the outer if
 
 <pre>
   <i>switch-statement:</i>
-    switch  (  <i>expression</i>  )  <i>compound-statement</i>
-    switch  (  <i>expression</i>  )  :   <i>statement-list</i>  endswitch;
+    switch  (  <i>expression</i>  )  {   <i>labeled-statement-list<sub>opt</sub></i>  }
+    switch  (  <i>expression</i>  )  :   <i>labeled-statement-list<sub>opt</sub></i>  endswitch;
 </pre>
 
-*expression* is defined in [§§](10-expressions.md#general-6); and *compound-statement* and
-*statement-list* are defined in [§§](#compound-statements).
+*expression* is defined in [§§](10-expressions.md#general-6); and *labeled-statement-list* is defined in[§§](#labeled-statements).
 
 **Constraints**
 
-The controlling expression *expression* must have scalar type.
+The *labeled-statement-list* in the second alternative (in the alternative syntax) must not contain any *compound-statement*'s.
 
-The *statement-list* must not contain any *compound-statement*'s.
+The expression of the case labels [§§](#labeled-statements) within the *labeled-statement-list* cannot be of an object type in the case where the *expression* evaluates to a numeric type. 
 
 There must be at most one default label.
 


### PR DESCRIPTION
The definition of a switch statement was written too wage, incorrectly respectively:
- a switch statement can only contain labeled-statement's and not arbitrary ones
- statements are optional in a switch statement
- removed constrained for control expression (PHP does not force the expression to be a scalar: http://3v4l.org/3KZlG)
- added constraint for case label expressions (maybe this was meant with control expression, anyway it was not correct entirely) (http://3v4l.org/lIMZJ / http://3v4l.org/5gDZM)