### PR TITLE
Update numeric string spec for PHP 7

### DIFF
--- a/spec/05-types.md
+++ b/spec/05-types.md
@@ -115,13 +115,33 @@ library functions assume the strings they receive as arguments are UTF-8
 encoded, often without explicitly mentioning that fact.
 
 A *numeric string* is a string whose content exactly matches the pattern
-defined using integer format by the production *integer-literal*
-([§§](09-lexical-structure.md#integer-literals)) or using floating-point format by the production
-*floating-literal* ([§§](09-lexical-structure.md#floating-point-literals)), where leading whitespace is permitted.
+defined by the *str-numeric* production defined in the following.
 A *leading-numeric string* is a string whose initial characters follow
 the requirements of a numeric string, and whose trailing characters are
 non-numeric. A *non-numeric string* is a string that is not a numeric
 string.
+
+<pre>
+  <i>str-numeric::</i>
+    <i>str-whitespace<sub>opt</sub></i>
+    <i>sign<sub>opt</sub></i>
+    <i>str-number</i>
+
+  <i>str-whitespace::</i>
+    <i>str-whitespace-char</i> 
+    <i>str-whitespace str-whitespace-char</i>
+
+  <i>str-whitespace-char::</i>
+    <i>new-line</i>
+    Space character (U+0020)
+    Horizontal-tab character (U+0009)
+    Vertical-tab character (U+000B)
+    Form-feed character (U+000C)
+
+  <i>str-number::</i>
+    <i>digit-sequence</i>
+    <i>floating-literal</i>
+</pre>
 
 Only one mutation operation may be performed on a string, offset
 assignment, which involves the simple assignment operator = ([§§](10-expressions.md#simple-assignment)).

--- a/tests/expressions/postfix_operators/post-increment_and_decrement.phpt
+++ b/tests/expressions/postfix_operators/post-increment_and_decrement.phpt
@@ -1,5 +1,5 @@
 --TEST--
-PHP Spec test generated from ./expressions/postfix_operators/post-increment_and_decrement.php
+Postscript increment and decrement
 --FILE--
 <?php
 
@@ -110,7 +110,7 @@ incdecrev("9223372036854775807");
 //*/
 
 ///*
-// test if number bases other than decimal are supported
+// test that number bases other than decimal are not supported
 
 incdec("012");
 incdecrev("012");
@@ -475,31 +475,31 @@ $a = 11 <---> int(11)
 --------------------------------------- end incdecrev ---
 --------------------------------------- start incdec ---
 $a = 0x12 <---> string(4) "0x12"
-$a = 17 <---> int(17)
-$a = 18 <---> int(18)
-$a = 18
-$a = 19 <---> int(19)
+$a = 0x12 <---> string(4) "0x12"
+$a = 0x13 <---> string(4) "0x13"
+$a = 0x13
+$a = 0x14 <---> string(4) "0x14"
 --------------------------------------- end incdec ---
 --------------------------------------- start incdecrev ---
 $a = 0x12 <---> string(4) "0x12"
-$a = 19 <---> int(19)
-$a = 18 <---> int(18)
-$a = 18
-$a = 17 <---> int(17)
+$a = 0x13 <---> string(4) "0x13"
+$a = 0x13 <---> string(4) "0x13"
+$a = 0x13
+$a = 0x13 <---> string(4) "0x13"
 --------------------------------------- end incdecrev ---
 --------------------------------------- start incdec ---
 $a = 0X12 <---> string(4) "0X12"
-$a = 17 <---> int(17)
-$a = 18 <---> int(18)
-$a = 18
-$a = 19 <---> int(19)
+$a = 0X12 <---> string(4) "0X12"
+$a = 0X13 <---> string(4) "0X13"
+$a = 0X13
+$a = 0X14 <---> string(4) "0X14"
 --------------------------------------- end incdec ---
 --------------------------------------- start incdecrev ---
 $a = 0X12 <---> string(4) "0X12"
-$a = 19 <---> int(19)
-$a = 18 <---> int(18)
-$a = 18
-$a = 17 <---> int(17)
+$a = 0X13 <---> string(4) "0X13"
+$a = 0X13 <---> string(4) "0X13"
+$a = 0X13
+$a = 0X13 <---> string(4) "0X13"
 --------------------------------------- end incdecrev ---
 --------------------------------------- start incdec ---
 $a = 0b101 <---> string(5) "0b101"

--- a/tests/expressions/unary_operators/pre-increment_and_decrement.phpt
+++ b/tests/expressions/unary_operators/pre-increment_and_decrement.phpt
@@ -1,5 +1,5 @@
 --TEST--
-PHP Spec test generated from ./expressions/unary_operators/pre-increment_and_decrement.php
+Prefix increment and decrement
 --FILE--
 <?php
 
@@ -500,35 +500,35 @@ $a = 14 <---> int(14)
 --------------------------------------- end incdecrev ---
 --------------------------------------- start incdec ---
 $a = 0x12 <---> string(4) "0x12"
-$a = 17 <---> int(17)
-$a = 16 <---> int(16)
-$a = 17 <---> int(17)
-$a = 18
-$a = 18 <---> int(18)
+$a = 0x12 <---> string(4) "0x12"
+$a = 0x12 <---> string(4) "0x12"
+$a = 0x13 <---> string(4) "0x13"
+$a = 0x14
+$a = 0x14 <---> string(4) "0x14"
 --------------------------------------- end incdec ---
 --------------------------------------- start incdecrev ---
 $a = 0x12 <---> string(4) "0x12"
-$a = 19 <---> int(19)
-$a = 20 <---> int(20)
-$a = 19 <---> int(19)
-$a = 20
-$a = 20 <---> int(20)
+$a = 0x13 <---> string(4) "0x13"
+$a = 0x14 <---> string(4) "0x14"
+$a = 0x14 <---> string(4) "0x14"
+$a = 0x15
+$a = 0x15 <---> string(4) "0x15"
 --------------------------------------- end incdecrev ---
 --------------------------------------- start incdec ---
 $a = 0X12 <---> string(4) "0X12"
-$a = 17 <---> int(17)
-$a = 16 <---> int(16)
-$a = 17 <---> int(17)
-$a = 18
-$a = 18 <---> int(18)
+$a = 0X12 <---> string(4) "0X12"
+$a = 0X12 <---> string(4) "0X12"
+$a = 0X13 <---> string(4) "0X13"
+$a = 0X14
+$a = 0X14 <---> string(4) "0X14"
 --------------------------------------- end incdec ---
 --------------------------------------- start incdecrev ---
 $a = 0X12 <---> string(4) "0X12"
-$a = 19 <---> int(19)
-$a = 20 <---> int(20)
-$a = 19 <---> int(19)
-$a = 20
-$a = 20 <---> int(20)
+$a = 0X13 <---> string(4) "0X13"
+$a = 0X14 <---> string(4) "0X14"
+$a = 0X14 <---> string(4) "0X14"
+$a = 0X15
+$a = 0X15 <---> string(4) "0X15"
 --------------------------------------- end incdecrev ---
 --------------------------------------- start incdec ---
 $a = 0b101 <---> string(5) "0b101"


### PR DESCRIPTION
 * Clarify what whitespace is supported - this is not the same as the white-space production.
 * Clarify that a sign is supported (which is not the case for the normal int/float productions)
 * Clarify that we only support decimal digits (including leading zeros) or float literals