### PR TITLE
Fix typo in Unicode escape test

### DIFF
--- a/tests/lexical_structure/unicode_string_escape_sequence/unicode_escape_incomplete.phpt
+++ b/tests/lexical_structure/unicode_string_escape_sequence/unicode_escape_incomplete.phpt
@@ -3,6 +3,6 @@ PHP Spec test generated from ./lexical_structure/unicode_string_escape_sequence/
 --FILE--
 <?php
 
-var_dunp("\u{blah");
+var_dump("\u{blah");
 --EXPECTF--
 Fatal error: Invalid UTF-8 codepoint escape sequence in %s on line %d


### PR DESCRIPTION
Fixed matching php-src test here: https://github.com/php/php-src/commit/05ef3b7c0de6d85480bc1dff3b1a4db5b06a3ad1