### PR TITLE
try-statement is unreachable

### DIFF
--- a/spec/11-statements.md
+++ b/spec/11-statements.md
@@ -13,6 +13,7 @@
     <i>selection-statement</i>
     <i>iteration-statement</i>
     <i>jump-statement</i>
+    <i>try-statement</i>
     <i>declare-statement</i>
     <i>const-declaration</i>
     <i>function-definition</i>


### PR DESCRIPTION
I just added `try-statement` to `statement` so that it can be recognized by the syntactical analyzer. It was unreachable from the start nonterminal. 