### PR TITLE
Fix class-declaration grammar

### DIFF
--- a/spec/14-classes.md
+++ b/spec/14-classes.md
@@ -58,7 +58,15 @@ object. As such, assignment of a handle does not copy the object itself.
 
 <pre>
   <i>class-declaration:</i>
-    <i>class-modifier<sub>opt</sub></i>  class  <i>name   class-base-clause<sub>opt</sub>  class-interface-clause<sub>opt</sub></i>   {   <i>trait-use-clauses<sub>opt</sub>   class-member-declarations<sub>opt</sub></i> }
+    <i>class-modifier<sub>opt</sub></i>  class  <i>name   class-base-clause<sub>opt</sub>  class-interface-clause<sub>opt</sub></i>   {   <i>class-members<sub>opt</sub></i>   }
+    
+   <i>class-members:</i>
+    <i>class-member</i>
+    <i>class-members   class-member</i>
+    
+   <i>class-member:</i>
+    <i>trait-use-clauses</i>
+    <i>class-member-declarations</i>
 
   <i>class-modifier:</i>
     abstract


### PR DESCRIPTION
Allow use trait clauses and other class members to be intermixed