### PR TITLE
Allow specifying keys on list() elements

### DIFF
--- a/spec/10-expressions.md
+++ b/spec/10-expressions.md
@@ -414,9 +414,17 @@ isset($v1, $v2, $v3);  // results in FALSE
     list  (  <i>list-expression-list<sub>opt</sub></i>  )
 
   <i>list-expression-list:</i>
+    <i>unkeyed-list-expression-list</i>
+    <i>keyed-list-expression-list</i> ,<sub>opt</sub>
+
+  <i>unkeyed-list-expression-list:</i>
     <i>list-or-variable</i>
     ,
-    <i>list-expression-list</i>  ,  <i>list-or-variable<sub>opt</sub></i>
+    <i>unkeyed-list-expression-list</i>  ,  <i>list-or-variable<sub>opt</sub></ii>
+
+  <i>keyed-list-expression-list:</i>
+    <i>expression</i>  =>  <i>list-or-variable</i>
+    <i>keyed-list-expression-list</i>  ,  <i>expression</i>  =>  <i>list-or-variable</i>
 
   <i>list-or-variable:</i>
     <i>list-intrinsic</i>
@@ -446,7 +454,8 @@ target variables. On success, it returns a copy of the source array. If the
 source array is not an array or object implementing `ArrayAccess` no
 assignments are performed and the return value is `NULL`.
 
-All elements in the source array having keys of type `string` are ignored.
+For *unkeyed-list-expression-list*, all elements in the source array having 
+keys of type `string` are ignored.
 The element having an `int` key of 0 is assigned to the first target
 variable, the element having an `int` key of 1 is assigned to the second
 target variable, and so on, until all target variables have been
@@ -454,6 +463,15 @@ assigned. Any other array elements are ignored. If there are
 fewer source array elements having int keys than there are target
 variables, the unassigned target variables are set to `NULL` and
 a non-fatal error is produced.
+
+For *keyed-list-expression-list*, each key-variable pair is handled in turn,
+with the key and variable being separated by the `=>` symbol.
+The element having the first key, with the key having been converted using the
+same rules as the [subscript operator](10-expressions.md#subscript-operator),
+is assigned to the frst target variable. This process is repeated for the
+second `=>` pair, if any, and so on. Any other array elements are ignored.
+If there is no array element with a given key, the unassigned target variable
+is set to `NULL` and a non-fatal error is produced.
 
 The assignments must occur in this order. 
 
@@ -481,6 +499,24 @@ list($arr[1], $arr[0]) = [0, 1];
   // $arr is [1 => 0, 0 => 1], in this order
 list($arr2[], $arr2[]) = [0, 1];
   // $arr2 is [0, 1]
+
+list("one" => $one, "two" => $two) = ["one" => 1, "two" => 2];
+  // $one is 1, $two is 2
+list(
+    "one" => $one,
+    "two" => $two,
+) = [
+    "one" => 1,
+    "two" => 2,
+];
+  // $one is 1, $two is 2
+list(list("x" => $x1, "y" => $y1), list("x" => $x2, "y" => $y2)) = [
+    ["x" => 1, "y" => 2],
+    ["x" => 3, "y" => 4]
+];
+  // $x1 is 1, $y1 is 2, $x2 is 3, $y2 is 4
+list(0 => list($x1, $x2), 1 => list($x2, $y2)) = [[1, 2], [3, 4]];
+  // $x1 is 1, $y1 is 2, $x2 is 3, $y2 is 4
 ```
 
 ####print

--- a/spec/19-grammar.md
+++ b/spec/19-grammar.md
@@ -426,9 +426,17 @@ The grammar notation is described in [Grammars section](09-lexical-structure.md#
     list  (  <i>list-expression-list<sub>opt</sub></i>  )
 
   <i>list-expression-list:</i>
+    <i>unkeyed-list-expression-list</i>
+    <i>keyed-list-expression-list</i> ,<sub>opt</sub>
+
+  <i>unkeyed-list-expression-list:</i>
     <i>list-or-variable</i>
     ,
-    <i>list-expression-list</i>  ,  <i>list-or-variable<sub>opt</sub></i>
+    <i>unkeyed-list-expression-list</i>  ,  <i>list-or-variable<sub>opt</sub></i>
+
+  <i>keyed-list-expression-list:</i>
+    <i>expression</i>  =>  <i>list-or-variable</i>
+    <i>keyed-list-expression-list</i>  ,  <i>expression</i>  =>  <i>list-or-variable</i>
 
   <i>list-or-variable:</i>
     <i>list-intrinsic</i>

--- a/tests/expressions/list/list_001.phpt
+++ b/tests/expressions/list/list_001.phpt
@@ -1,0 +1,14 @@
+--TEST--
+"Nested" list()
+--FILE--
+<?php
+
+list($a, list($b)) = array(new stdclass, array(new stdclass));
+var_dump($a, $b);
+
+?>
+--EXPECT--
+object(stdClass)#1 (0) {
+}
+object(stdClass)#2 (0) {
+}

--- a/tests/expressions/list/list_002.phpt
+++ b/tests/expressions/list/list_002.phpt
@@ -1,0 +1,20 @@
+--TEST--
+Testing full-reference on list()
+--FILE--
+<?php
+
+error_reporting(E_ALL);
+
+$a = new stdclass;
+$b =& $a;
+
+list($a, list($b)) = array($a, array($b));
+var_dump($a, $b, $a === $b);
+
+?>
+--EXPECT--
+object(stdClass)#1 (0) {
+}
+object(stdClass)#1 (0) {
+}
+bool(true)

--- a/tests/expressions/list/list_003.phpt
+++ b/tests/expressions/list/list_003.phpt
@@ -1,0 +1,24 @@
+--TEST--
+list() with non-array
+--FILE--
+<?php
+
+list($a) = NULL;
+
+list($b) = 1;
+
+list($c) = 1.;
+
+list($d) = 'foo';
+
+list($e) = print '';
+
+var_dump($a, $b, $c, $d, $e);
+
+?>
+--EXPECT--
+NULL
+NULL
+NULL
+NULL
+NULL

--- a/tests/expressions/list/list_004.phpt
+++ b/tests/expressions/list/list_004.phpt
@@ -1,0 +1,21 @@
+--TEST--
+list() with array reference
+--FILE--
+<?php
+
+$arr = array(2, 1);
+$b =& $arr;
+
+list(,$a) = $b;
+
+var_dump($a, $b);
+
+?>
+--EXPECT--
+int(1)
+array(2) {
+  [0]=>
+  int(2)
+  [1]=>
+  int(1)
+}

--- a/tests/expressions/list/list_005.phpt
+++ b/tests/expressions/list/list_005.phpt
@@ -1,0 +1,50 @@
+--TEST--
+Testing list() with several variables
+--FILE--
+<?php
+
+$str = "foo";
+
+list($a, $b, $c) = $str;
+
+var_dump($a, $b, $c);
+
+print "----\n";
+
+$int = 1;
+
+list($a, $b, $c) = $int;
+
+var_dump($a, $b, $c);
+
+print "----\n";
+
+$obj = new stdClass;
+
+list($a, $b, $c) = $obj;
+
+var_dump($a, $b, $c);
+
+print "----\n";
+
+$arr = array(1, 2, 3);
+
+list($a, $b, $c) = $arr;
+
+var_dump($a, $b, $c);
+
+?>
+--EXPECTF--
+NULL
+NULL
+NULL
+----
+NULL
+NULL
+NULL
+----
+
+Fatal error: Uncaught Error: Cannot use object of type stdClass as array in %s:%d
+Stack trace:
+#0 {main}
+  thrown in %s on line %d

--- a/tests/expressions/list/list_006.phpt
+++ b/tests/expressions/list/list_006.phpt
@@ -1,0 +1,12 @@
+--TEST--
+Testing nested list() with empty array
+--FILE--
+<?php
+
+list($a, list($b, list(list($d)))) = array();
+
+?>
+--EXPECTF--
+Notice: Undefined offset: 0 in %s on line %d
+
+Notice: Undefined offset: 1 in %s on line %d

--- a/tests/expressions/list/list_007.phpt
+++ b/tests/expressions/list/list_007.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Using lambda with list()
+--FILE--
+<?php
+
+list($x, $y) = function() { };
+
+var_dump($x, $y);
+
+?>
+--EXPECTF--
+Fatal error: Uncaught Error: Cannot use object of type Closure as array in %slist_007.php:3
+Stack trace:
+#0 {main}
+  thrown in %slist_007.php on line 3

--- a/tests/expressions/list/list_destructuring_to_special_variables.phpt
+++ b/tests/expressions/list/list_destructuring_to_special_variables.phpt
@@ -1,0 +1,49 @@
+--TEST--
+list() can be used to destructure to string offsets, __set and ArrayAccess::offsetSet
+--FILE--
+<?php
+
+class Obj {
+    public $values = [];
+    public function __set($name, $value) {
+        $this->values[$name] = $value;
+    }
+}
+
+class Arr implements ArrayAccess {
+    public $values = [];
+    public function offsetSet($name, $value) {
+        $this->values[$name] = $value;
+    }
+    public function offsetGet($name) {}
+    public function offsetExists($name) {}
+    public function offsetUnset($name) {}
+}
+
+$str = 'ab';
+list($str[0], $str[1]) = ['x', 'y'];
+var_dump($str);
+
+$obj = new Obj;
+list($obj->foo, $obj->bar) = ['foo', 'bar'];
+var_dump($obj->values);
+
+$arr = new Arr;
+list($arr['foo'], $arr['bar']) = ['foo', 'bar'];
+var_dump($arr->values);
+
+?>
+--EXPECT--
+string(2) "xy"
+array(2) {
+  ["foo"]=>
+  string(3) "foo"
+  ["bar"]=>
+  string(3) "bar"
+}
+array(2) {
+  ["foo"]=>
+  string(3) "foo"
+  ["bar"]=>
+  string(3) "bar"
+}

--- a/tests/expressions/list/list_empty_error.phpt
+++ b/tests/expressions/list/list_empty_error.phpt
@@ -1,0 +1,10 @@
+--TEST--
+Empty list() assignments are not allowed
+--FILE--
+<?php
+
+list(,,,,,,,,,,) = [];
+
+?>
+--EXPECTF--
+Fatal error: Cannot use empty list in %s on line %d

--- a/tests/expressions/list/list_keyed.phpt
+++ b/tests/expressions/list/list_keyed.phpt
@@ -1,0 +1,71 @@
+--TEST--
+list() with keys
+--FILE--
+<?php
+
+$antonyms = [
+    "good" => "bad",
+    "happy" => "sad",
+];
+
+list("good" => $good_antonym, "happy" => $happy_antonym) = $antonyms;
+var_dump($good_antonym, $happy_antonym);
+
+echo PHP_EOL;
+
+$powersOfTwo = [
+    1 => 2,
+    2 => 4,
+    3 => 8
+];
+
+list(1 => $two_1, 2 => $two_2, 3 => $two_3) = $powersOfTwo;
+var_dump($two_1, $two_2, $two_3);
+
+echo PHP_EOL;
+
+$contrivedMixedKeyTypesExample = [
+    7 => "the best PHP version",
+    "elePHPant" => "the cutest mascot"
+];
+
+list(7 => $seven, "elePHPant" => $elePHPant) = $contrivedMixedKeyTypesExample;
+var_dump($seven, $elePHPant);
+
+echo PHP_EOL;
+
+$allTogetherNow = [
+    "antonyms" => $antonyms,
+    "powersOfTwo" => $powersOfTwo,
+    "contrivedMixedKeyTypesExample" => $contrivedMixedKeyTypesExample
+];
+
+list(
+    "antonyms" => list("good" => $good_antonym, "happy" => $happy_antonym),
+    "powersOfTwo" => list(1 => $two_1, 2 => $two_2, 3 => $two_3),
+    "contrivedMixedKeyTypesExample" => list(7 => $seven, "elePHPant" => $elePHPant)
+) = $allTogetherNow;
+
+var_dump($good_antonym, $happy_antonym);
+var_dump($two_1, $two_2, $two_3);
+var_dump($seven, $elePHPant);
+
+?>
+--EXPECT--
+string(3) "bad"
+string(3) "sad"
+
+int(2)
+int(4)
+int(8)
+
+string(20) "the best PHP version"
+string(17) "the cutest mascot"
+
+string(3) "bad"
+string(3) "sad"
+int(2)
+int(4)
+int(8)
+string(20) "the best PHP version"
+string(17) "the cutest mascot"

--- a/tests/expressions/list/list_keyed_ArrayAccess.phpt
+++ b/tests/expressions/list/list_keyed_ArrayAccess.phpt
@@ -1,0 +1,54 @@
+--TEST--
+list() with keys and ArrayAccess
+--FILE--
+<?php
+
+$antonymObject = new ArrayObject;
+$antonymObject["good"] = "bad";
+$antonymObject["happy"] = "sad";
+
+list("good" => $good, "happy" => $happy) = $antonymObject;
+var_dump($good, $happy);
+
+echo PHP_EOL;
+
+$stdClassCollection = new SplObjectStorage;
+$foo = new StdClass;
+$stdClassCollection[$foo] = "foo";
+$bar = new StdClass;
+$stdClassCollection[$bar] = "bar";
+
+list($foo => $fooStr, $bar => $barStr) = $stdClassCollection;
+var_dump($fooStr, $barStr);
+
+echo PHP_EOL;
+
+class IndexPrinter implements ArrayAccess
+{
+    public function offsetGet($offset) {
+        echo "GET ";
+        var_dump($offset);
+    }
+    public function offsetSet($offset, $value) {
+    }
+    public function offsetExists($offset) {
+    }
+    public function offsetUnset($offset) {
+    }
+}
+
+$op = new IndexPrinter;
+list(123 => $x) = $op;
+// PHP shouldn't convert this to an integer offset, because it's ArrayAccess
+list("123" => $x) = $op;
+
+?>
+--EXPECT--
+string(3) "bad"
+string(3) "sad"
+
+string(3) "foo"
+string(3) "bar"
+
+GET int(123)
+GET string(3) "123"

--- a/tests/expressions/list/list_keyed_conversions.phpt
+++ b/tests/expressions/list/list_keyed_conversions.phpt
@@ -1,0 +1,32 @@
+--TEST--
+list() with non-integer-or-string keys
+--FILE--
+<?php
+
+$results = [
+    0 => 0,
+    1 => 1,
+    "" => ""
+];
+
+list(NULL => $NULL, 1.5 => $float, FALSE => $FALSE, TRUE => $TRUE) = $results;
+var_dump($NULL, $float, $FALSE, $TRUE);
+
+echo PHP_EOL;
+
+list("0" => $zeroString, "1" => $oneString) = $results;
+var_dump($zeroString, $oneString);
+
+list(STDIN => $resource) = [];
+
+?>
+--EXPECTF--
+string(0) ""
+int(1)
+int(0)
+int(1)
+
+int(0)
+int(1)
+
+Notice: Resource ID#%d used as offset, casting to integer (%d) in %s on line %d

--- a/tests/expressions/list/list_keyed_evaluation_order.inc
+++ b/tests/expressions/list/list_keyed_evaluation_order.inc
@@ -1,0 +1,60 @@
+<?php declare(strict_types=1);
+
+// Observer objects for the Zend/tests/list_keyed_evaluation_order.* tests
+
+class Stringable
+{
+    private $name;
+    public function __construct(string $name) {
+        $this->name = $name;
+    }
+
+    public function __toString(): string {
+        echo "$this->name evaluated.", PHP_EOL;
+        return $this->name;
+    }
+}
+
+class Indexable implements ArrayAccess
+{
+    private $array;
+    public function __construct(array $array) {
+        $this->array = $array;
+    }
+
+    public function offsetExists($offset): bool {
+        echo "Existence of offset $offset checked for.", PHP_EOL;
+        return isset($this->array[$offset]);
+    }
+
+    public function offsetUnset($offset): void {
+        unset($this->array[$offset]);
+        echo "Offset $offset removed.", PHP_EOL;
+    }
+
+    public function offsetGet($offset) {
+        echo "Offset $offset retrieved.", PHP_EOL;
+        return $this->array[$offset];
+    }
+
+    public function offsetSet($offset, $value): void {
+        $this->array[$offset] = $value;
+        echo "Offset $offset set to $value.", PHP_EOL;
+    }
+}
+
+class IndexableRetrievable
+{
+    private $label;
+    private $indexable;
+    
+    public function __construct(string $label, Indexable $indexable) {
+        $this->label = $label;
+        $this->indexable = $indexable;
+    }
+
+    public function getIndexable(): Indexable {
+        echo "Indexable $this->label retrieved.", PHP_EOL;
+        return $this->indexable;
+    }
+}

--- a/tests/expressions/list/list_keyed_evaluation_order.phpt
+++ b/tests/expressions/list/list_keyed_evaluation_order.phpt
@@ -1,0 +1,35 @@
+--TEST--
+list() with keys, evaluation order
+--FILE--
+<?php
+
+require_once "list_keyed_evaluation_order.inc";
+
+$a = new Stringable("A");
+$c = new Stringable("C");
+
+$e = new IndexableRetrievable("E", new Indexable(["A" => "value for offset A", "C" => "value for offset C"]));
+
+$store = new Indexable([]);
+
+// list($a => $b, $c => $d) = $e;
+// Should be evaluated in the order:
+// 1. Evaluate $e
+// 2. Evaluate $a
+// 3. Evaluate $e[$a]
+// 4. Assign $b from $e[$a]
+// 5. Evaluate $c
+// 6. Evaluate $e[$c]
+// 7. Assign $c from $e[$a]
+
+list((string)$a => $store["B"], (string)$c => $store["D"]) = $e->getIndexable();
+
+?>
+--EXPECT--
+Indexable E retrieved.
+A evaluated.
+Offset A retrieved.
+Offset B set to value for offset A.
+C evaluated.
+Offset C retrieved.
+Offset D set to value for offset C.

--- a/tests/expressions/list/list_keyed_evaluation_order_2.phpt
+++ b/tests/expressions/list/list_keyed_evaluation_order_2.phpt
@@ -1,0 +1,77 @@
+--TEST--
+list() with keys, evaluation order #2
+--FILE--
+<?php
+
+// All the following should print 'a' then 'b'
+
+list($a, $b) = ['a', 'b'];
+var_dump($a);
+var_dump($b);
+
+list(0 => $a, 1 => $b) = ['a', 'b'];
+var_dump($a);
+var_dump($b);
+
+list(1 => $b, 0 => $a) = ['a', 'b'];
+var_dump($a);
+var_dump($b);
+
+$arr = [];
+list($arr[], $arr[]) = ['a', 'b'];
+var_dump($arr[0]);
+var_dump($arr[1]);
+
+$arr = [];
+list(0 => $arr[], 1 => $arr[]) = ['a', 'b'];
+var_dump($arr[0]);
+var_dump($arr[1]);
+
+$arr = [];
+list(1 => $arr[], 0 => $arr[]) = ['b', 'a'];
+var_dump($arr[0]);
+var_dump($arr[1]);
+
+$arr = [];
+list(list(1 => $arr[], 0 => $arr[])) = [['b', 'a']];
+var_dump($arr[0]);
+var_dump($arr[1]);
+
+$arr = [];
+list('key1' => $arr[], 'key2' => $arr[]) = ['key2' => 'b', 'key1' => 'a'];
+var_dump($arr[0]);
+var_dump($arr[1]);
+
+// This should print 'foo'
+$a = 0;
+list($a => $a) = ['foo', 'bar'];
+var_dump($a);
+
+// This should print 'bar' then 'foo'
+$a = 0;
+$b = 1;
+list($b => $a, $a => $c) = ['bar' => 'foo', 1 => 'bar'];
+var_dump($a);
+var_dump($c);
+
+?>
+--EXPECT--
+string(1) "a"
+string(1) "b"
+string(1) "a"
+string(1) "b"
+string(1) "a"
+string(1) "b"
+string(1) "a"
+string(1) "b"
+string(1) "a"
+string(1) "b"
+string(1) "a"
+string(1) "b"
+string(1) "a"
+string(1) "b"
+string(1) "a"
+string(1) "b"
+string(3) "foo"
+string(3) "bar"
+string(3) "foo"

--- a/tests/expressions/list/list_keyed_evaluation_order_3.phpt
+++ b/tests/expressions/list/list_keyed_evaluation_order_3.phpt
@@ -1,0 +1,24 @@
+--TEST--
+list() with keys, evaluation order #3
+--FILE--
+<?php
+
+$i = 0;
+$a = [
+    0 => [
+        'b' => 'bar',
+        'a' => 'foo',
+    ],
+    1 => 'a',
+    3 => 'b',
+];
+list($a[$i++] => $a[$i++], $a[$i++] => $a[$i++]) = $a[$i++];
+var_dump($i); // should be 5
+var_dump($a[2]); // should be 'foo'
+var_dump($a[4]); // should be 'bar'
+
+?>
+--EXPECT--
+int(5)
+string(3) "foo"
+string(3) "bar"

--- a/tests/expressions/list/list_keyed_evaluation_order_nested.phpt
+++ b/tests/expressions/list/list_keyed_evaluation_order_nested.phpt
@@ -1,0 +1,77 @@
+--TEST--
+list() with keys, evaluation order: nested
+--FILE--
+<?php
+
+require_once "list_keyed_evaluation_order.inc";
+
+$a = new Stringable("A");
+$c = new Stringable("C");
+$f = new Stringable("F");
+$g = new Stringable("G");
+$i = new Stringable("I");
+
+$k = new IndexableRetrievable("K", new Indexable([
+    "A" => "offset value for A",
+    "C" => new Indexable([
+        0 => "offset value for 0",
+        1 => "offset value for 1"
+    ]),
+    "F" => new Indexable([
+        "G" => "offset value for G",
+        "I" => "offset value for I"
+    ])
+]));
+
+$store = new Indexable([]);
+
+// list($a => $b, $c => list($d, $e), $f => list($g => $h, $i => $j)) = $k;
+// Should be evaluated in the order:
+// 1. Evaluate $k
+// 2. Evaluate $a
+// 3. Evaluate $k[$a]
+// 4. Assign $b from $k[$a]
+// 5. Evaluate $c
+// 6. Evaluate $k[$c]
+// 7. Evaluate $k[$c][0]
+// 8. Assign $d from $k[$c][0]
+// 9. Evaluate $k[$c][1]
+// 10. Assign $e from $k[$c][1]
+// 11. Evaluate $f
+// 12. Evaluate $k[$f]
+// 13. Evaluate $g
+// 14. Evaluate $k[$f][$g]
+// 15. Assign $h from $k[$f][$g]
+// 16. Evaluate $i
+// 17. Evaluate $k[$f][$i]
+// 18. Assign $j from $k[$f][$i]
+
+list(
+    (string)$a => $store["B"],
+    (string)$c => list($store["D"], $store["E"]),
+    (string)$f => list(
+        (string)$g => $store["H"],
+        (string)$i => $store["J"]
+    )
+) = $k->getIndexable();
+
+?>
+--EXPECT--
+Indexable K retrieved.
+A evaluated.
+Offset A retrieved.
+Offset B set to offset value for A.
+C evaluated.
+Offset C retrieved.
+Offset 0 retrieved.
+Offset D set to offset value for 0.
+Offset 1 retrieved.
+Offset E set to offset value for 1.
+F evaluated.
+Offset F retrieved.
+G evaluated.
+Offset G retrieved.
+Offset H set to offset value for G.
+I evaluated.
+Offset I retrieved.
+Offset J set to offset value for I.

--- a/tests/expressions/list/list_keyed_non_literals.phpt
+++ b/tests/expressions/list/list_keyed_non_literals.phpt
@@ -1,0 +1,30 @@
+--TEST--
+list() with constant keys
+--FILE--
+<?php
+
+$arr = [
+    1 => "one",
+    2 => "two",
+    3 => "three"
+];
+
+const COMPILE_TIME_RESOLVABLE = 1;
+
+define('PROBABLY_NOT_COMPILE_TIME_RESOLVABLE', file_get_contents("data:text/plain,2"));
+
+$probablyNotCompileTimeResolvable3 = cos(0) * 3;
+
+list(
+    COMPILE_TIME_RESOLVABLE => $one,
+    PROBABLY_NOT_COMPILE_TIME_RESOLVABLE => $two,
+    $probablyNotCompileTimeResolvable3 => $three
+) = $arr;
+
+var_dump($one, $two, $three);
+
+?>
+--EXPECTF--
+string(3) "one"
+string(3) "two"
+string(5) "three"

--- a/tests/expressions/list/list_keyed_trailing_comma.phpt
+++ b/tests/expressions/list/list_keyed_trailing_comma.phpt
@@ -1,0 +1,38 @@
+--TEST--
+list() with keys and a trailing comma
+--FILE--
+<?php
+
+$antonyms = [
+    "good" => "bad",
+    "happy" => "sad",
+];
+
+list(
+    "good" => $good,
+    "happy" => $happy
+) = $antonyms;
+
+var_dump($good, $happy);
+
+echo PHP_EOL;
+
+$antonyms = [
+    "good" => "bad",
+    "happy" => "sad",
+];
+
+list(
+    "good" => $good,
+    "happy" => $happy,
+) = $antonyms;
+
+var_dump($good, $happy);
+
+?>
+--EXPECT--
+string(3) "bad"
+string(3) "sad"
+
+string(3) "bad"
+string(3) "sad"

--- a/tests/expressions/list/list_keyed_undefined.phpt
+++ b/tests/expressions/list/list_keyed_undefined.phpt
@@ -1,0 +1,22 @@
+--TEST--
+list() with undefined keys
+--FILE--
+<?php
+
+$contrivedMixedKeyTypesExample = [
+    7 => "the best PHP version",
+    "elePHPant" => "the cutest mascot"
+];
+
+list(5 => $five, "duke" => $duke) = $contrivedMixedKeyTypesExample;
+
+var_dump($five, $duke);
+
+?>
+--EXPECTF--
+
+Notice: Undefined offset: 5 in %s on line %d
+
+Notice: Undefined index: duke in %s on line %d
+NULL
+NULL

--- a/tests/expressions/list/list_mixed_keyed_unkeyed.phpt
+++ b/tests/expressions/list/list_mixed_keyed_unkeyed.phpt
@@ -1,0 +1,16 @@
+--TEST--
+list() with both keyed and unkeyed elements
+--FILE--
+<?php
+
+$contrivedKeyedAndUnkeyedArrayExample = [
+    0,
+    1 => 1,
+    "foo" => "bar"
+];
+
+list($zero, 1 => $one, "foo" => $foo) = $contrivedKeyedAndUnkeyedArrayExample;
+
+?>
+--EXPECTF--
+Parse error: syntax error, unexpected %s in %s on line %d

--- a/tests/expressions/list/list_mixed_nested_keyed_unkeyed.phpt
+++ b/tests/expressions/list/list_mixed_nested_keyed_unkeyed.phpt
@@ -1,0 +1,34 @@
+--TEST--
+list() with nested unkeyed and keyed list()
+--FILE--
+<?php
+
+$points = [
+    ["x" => 1, "y" => 2],
+    ["x" => 2, "y" => 1]
+];
+
+list(list("x" => $x1, "y" => $y1), list("x" => $x2, "y" => $y2)) = $points;
+var_dump($x1, $y1, $x2, $y2);
+
+echo PHP_EOL;
+
+$invertedPoints = [
+    "x" => [1, 2],
+    "y" => [2, 1]
+];
+
+list("x" => list($x1, $x2), "y" => list($y1, $y2)) = $invertedPoints;
+var_dump($x1, $y1, $x2, $y2);
+
+?>
+--EXPECT--
+int(1)
+int(2)
+int(2)
+int(1)
+
+int(1)
+int(2)
+int(2)
+int(1)

--- a/tests/expressions/list/list_self_assign.phpt
+++ b/tests/expressions/list/list_self_assign.phpt
@@ -1,0 +1,56 @@
+--TEST--
+Test variable occuring on both LHS and RHS of list()
+--FILE--
+<?php
+
+$a = [1, 2, 3];
+list($a, $b, $c) = $a;
+var_dump($a, $b, $c);
+
+$b = [1, 2, 3];
+list($a, $b, $c) = $b;
+var_dump($a, $b, $c);
+
+$c = [1, 2, 3];
+list($a, $b, $c) = $c;
+var_dump($a, $b, $c);
+
+$a = [[1, 2], 3];
+list(list($a, $b), $c) = $a;
+var_dump($a, $b, $c);
+
+$b = [[1, 2], 3];
+list(list($a, $b), $c) = $b;
+var_dump($a, $b, $c);
+
+$b = [1, [2, 3]];
+list($a, list($b, $c)) = $b;
+var_dump($a, $b, $c);
+
+$c = [1, [2, 3]];
+list($a, list($b, $c)) = $c;
+var_dump($a, $b, $c);
+
+?>
+--EXPECT--
+int(1)
+int(2)
+int(3)
+int(1)
+int(2)
+int(3)
+int(1)
+int(2)
+int(3)
+int(1)
+int(2)
+int(3)
+int(1)
+int(2)
+int(3)
+int(1)
+int(2)
+int(3)
+int(1)
+int(2)
+int(3)


### PR DESCRIPTION
Counterpart to the RFC: https://wiki.php.net/rfc/list_keys (which has been Accepted)

Counterpart `php-src` pull request: https://github.com/php/php-src/pull/1730 (not yet merged)