### PR TITLE
Removed Throwable Interface Method Modifiers

### DIFF
--- a/spec/15-interfaces.md
+++ b/spec/15-interfaces.md
@@ -230,14 +230,14 @@ This type is defined, as follows:
 
 ```PHP
 interface Throwable {
-  __toString(): string;
-  getCode(): int;
-  getFile(): string;
-  getLine(): int;
-  getMessage(): string;
-  getPrevious(): Throwable;
-  getTrace(): array;
-  getTraceAsString(): string;
+  function __toString(): string;
+  function getCode(): int;
+  function getFile(): string;
+  function getLine(): int;
+  function getMessage(): string;
+  function getPrevious(): Throwable;
+  function getTrace(): array;
+  function getTraceAsString(): string;
 }
 ```
 The interface members are defined below:

--- a/spec/15-interfaces.md
+++ b/spec/15-interfaces.md
@@ -230,14 +230,14 @@ This type is defined, as follows:
 
 ```PHP
 interface Throwable {
-  abstract public __toString(): string;
-  abstract public getCode(): int;
-  abstract public getFile(): string;
-  abstract public getLine(): int;
-  abstract public getMessage(): string;
-  abstract public getPrevious(): Throwable;
-  abstract public getTrace(): array;
-  abstract public getTraceAsString(): string;
+  __toString(): string;
+  getCode(): int;
+  getFile(): string;
+  getLine(): int;
+  getMessage(): string;
+  getPrevious(): Throwable;
+  getTrace(): array;
+  getTraceAsString(): string;
 }
 ```
 The interface members are defined below:


### PR DESCRIPTION
> All methods declared in an interface must be implicitly or explicitly
public, and they must not be declared `abstract`.

This quote is directly from the specification itself, however, the `Throwable` interface uses the `abstract` modifier and a `public` access modifier (unlike all other interfaces in the same document). I removed both modifiers from the methods in the `Throwable` interface example to ensure consistency.

And apparently the required `function` keyword was missing too.