### PR TITLE
Fix the whitespace definition

### DIFF
--- a/spec/09-lexical-structure.md
+++ b/spec/09-lexical-structure.md
@@ -157,7 +157,7 @@ though it was white space.
 ###White Space
 
 White space consists of an arbitrary combination of one or more
-new-line, space, horizontal tab, vertical tab, and form-feed characters.
+new-line, space and horizontal tab.
 
 **Syntax**
 


### PR DESCRIPTION
The vertical tab and the form-feed character are not part of the whitespaces.

Either the definition is wrong, or the rule. But they do not match 😄.