### PR TITLE
Fix constant-expression specification

### DIFF
--- a/spec/10-expressions.md
+++ b/spec/10-expressions.md
@@ -3468,20 +3468,22 @@ and relative path) still are considered the same file.
 <pre>
   <i>constant-expression:</i>
     <i>array-creation-expression</i>
-    <i>expression</i>
+    <i>literal</i>
+    <i>name</i>
 </pre>
 
 **Defined elsewhere**
 
 * [*array-creation-expression*](#array-creation-operator)
-* [*expression*](#general-6)
+* [*literal*](#literals)
+* [*name*](09-lexical-structure.md#names)
 
 **Constraints**
 
 All of the *element-key* and *element-value* elements in
 [*array-creation-expression*](#array-creation-operator) must be literals.
 
-*expression* must have a scalar type, and be a literal or the name of a [c-constant](06-constants.md#general).
+*name* must be the name of a [c-constant](06-constants.md#general).
 
 **Semantics**
 

--- a/spec/19-grammar.md
+++ b/spec/19-grammar.md
@@ -374,17 +374,11 @@ The grammar notation is described in [Grammars section](09-lexical-structure.md#
   <i>primary-expression:</i>
     <i>variable-name</i>
     <i>qualified-name</i>
-    <i>literal</i>
     <i>constant-expression</i>
     <i>intrinsic</i>
     <i>anonymous-function-creation-expression</i>
     (  <i>expression</i>  )
     $this
-
-  <i>literal:</i>
-    <i>integer-literal</i>
-    <i>floating-literal</i>
-    <i>string-literal</i>
 
   <i>intrinsic:</i>
     <i>intrisic-construct</i>
@@ -523,7 +517,7 @@ The grammar notation is described in [Grammars section](09-lexical-structure.md#
   <i>element-key:</i>
     <i>expression</i>
 
-  <i>element-value</i>
+  <i>element-value:</i>
     <i>expression</i>
 
   <i>subscript-expression:</i>
@@ -813,7 +807,13 @@ The grammar notation is described in [Grammars section](09-lexical-structure.md#
 <pre>
   <i>constant-expression:</i>
     <i>array-creation-expression</i>
-    <i>expression</i>
+    <i>literal</i>
+    <i>name</i>
+
+  <i>literal:</i>
+    <i>integer-literal</i>
+    <i>floating-literal</i>
+    <i>string-literal</i>
 </pre>
 
 ###Statements


### PR DESCRIPTION
Previously, a `constant-expression` was defined as a superset of `expression`, and a `primary-expression` as a superset of `constant-expression`, which causes confusion when attempting to parse the grammar for a few reasons:
  1. `constant-expression->array-creation-expression` and `expression->yield-expression-> ... -> postfix-expression -> array-creation-expression`, which meant that constant-expression was rendered completely redundant within the grammar.
  2. `primary-expression -> constant-expression -> expression`, which makes determining operator precedence challenging.
  3. `constant-expression->expression` is improperly specified as requiring a scalar type, when it could also be an array.

This fix addresses all of these issues by more concretely defining the constant-expression type in `19-grammar.md`, and updating the constraints defined in `10-expressions.md`.