### PR TITLE
fix orphaned try-statement in 19-grammar.md

### DIFF
--- a/spec/19-grammar.md
+++ b/spec/19-grammar.md
@@ -829,6 +829,7 @@ The grammar notation is described in [Grammars section](09-lexical-structure.md#
     <i>selection-statement</i>
     <i>iteration-statement</i>
     <i>jump-statement</i>
+    <i>try-statement</i>
     <i>declare-statement</i>
     <i>const-declaration</i>
     <i>function-definition</i>


### PR DESCRIPTION
`statement` should point to `try-statement`. This now matches the definition in `11-statements.md`