### PR TITLE
Make switch-statement definition more precise

### DIFF
--- a/spec/11-statements.md
+++ b/spec/11-statements.md
@@ -8,7 +8,7 @@
 
   <i>statement:</i>
     <i>compound-statement</i>
-    <i>labeled-statement</i>
+    <i>named-label-statement</i>
     <i>expression-statement</i>
     <i>selection-statement</i>
     <i>iteration-statement</i>
@@ -91,23 +91,8 @@ while (condition)
 **Syntax**
 
 <pre>
-  <i>labeled-statement:</i>
-    <i>named-label-statement</i>
-    <i>case-statement</i>
-    <i>default-statement</i>
-
   <i>named-label-statement:</i>
     <i>name</i>  :  <i>statement</i>
-
-  <i>case-statement:</i>
-    case   <i>expression   case-default-label-terminator   statement</i>
-
-  <i>default-statement:</i>
-    default  <i>case-default-label-terminator   statement</i>
-
-  <i>case-default-label-terminator:</i>
-    :
-    ;
 </pre>
 
 **Defined elsewhere**
@@ -121,8 +106,6 @@ while (condition)
 A named label can be used as the target of a [`goto` statement](#the-goto-statement).
 
 Named labels must be unique within a function.
-
-A case and default labeled statements must only occur inside a [`switch` statement](#the-switch-statement).
 
 **Semantics**
 
@@ -308,13 +291,21 @@ else  // this else does go with the outer if
   <i>case-statements:</i>
     <i>case-statement</i> <i>statement-list<sub>opt</sub></i> <i>case-statements<sub>opt</sub></i>
     <i>default-statement</i> <i>statement-list<sub>opt</sub></i> <i>case-statements<sub>opt</sub></i>
+
+  <i>case-statement:</i>
+    case   <i>expression   case-default-label-terminator   statement</i>
+
+  <i>default-statement:</i>
+    default  <i>case-default-label-terminator   statement</i>
+
+  <i>case-default-label-terminator:</i>
+    :
+    ;
 </pre>
 
 **Defined elsewhere**
 
 * [*expression*](10-expressions.md#general-6)
-* [*case-statement*](#labeled-statements)
-* [*default-statement*](#labeled-statements)
 * [*compound-statement*](#compound-statements)
 * [*statement-list*](#compound-statements)
 

--- a/spec/19-grammar.md
+++ b/spec/19-grammar.md
@@ -824,7 +824,7 @@ The grammar notation is described in [Grammars section](09-lexical-structure.md#
 
   <i>statement:</i>
     <i>compound-statement</i>
-    <i>labeled-statement</i>
+    <i>named-label-statement</i>
     <i>expression-statement</i>
     <i>selection-statement</i>
     <i>iteration-statement</i>
@@ -855,23 +855,8 @@ The grammar notation is described in [Grammars section](09-lexical-structure.md#
 ####Labeled Statements
 
 <pre>
-  <i>labeled-statement:</i>
-    <i>named-label-statement</i>
-    <i>case-statement</i>
-    <i>default-statement</i>
-
   <i>named-label-statement:</i>
     <i>name</i>  :  <i>statement</i>
-
-  <i>case-statement:</i>
-    case   <i>expression   case-default-label-terminator   statement</i>
-
-  <i>default-statement:</i>
-    default  <i>case-default-label-terminator   statement</i>
-
-  <i>case-default-label-terminator:</i>
-    :
-    ;
 </pre>
 
 ####Expression Statements
@@ -916,6 +901,15 @@ The grammar notation is described in [Grammars section](09-lexical-structure.md#
     <i>case-statement</i> <i>statement-list<sub>opt</sub></i> <i>case-statements<sub>opt</sub></i>
     <i>default-statement</i> <i>statement-list<sub>opt</sub></i> <i>case-statements<sub>opt</sub></i>
 
+  <i>case-statement:</i>
+    case   <i>expression   case-default-label-terminator   statement</i>
+
+  <i>default-statement:</i>
+    default  <i>case-default-label-terminator   statement</i>
+
+  <i>case-default-label-terminator:</i>
+    :
+    ;
 </pre>
 
 ####Iteration Statements


### PR DESCRIPTION
`case-statement` and `default-statement` usages must occur inside a `switch-statement`. Update the spec to represent this behavior more precisely in the grammar, rather than as an additional constraint.