### PR TITLE
`exit` with no parenthesis does have an opt. expr.

### DIFF
--- a/spec/10-expressions.md
+++ b/spec/10-expressions.md
@@ -340,10 +340,10 @@ eval("echo \$str . \"\\n\";");  // → echo $str . "\n"; → prints Hello
 
 <pre>
   <i>exit-intrinsic:</i>
-    exit  <i>expression<sub>opt</sub></i>
-    exit  (  <i>expression<sub>opt</sub></i>  )
-    die   <i>expression<sub>opt</sub></i>
-    die   (   <i>expression<sub>opt</sub></i> )
+    exit
+    exit   (   <i>expression<sub>opt</sub></i>   )
+    die
+    die   (   <i>expression<sub>opt</sub></i>   )
 </pre>
 
 **Defined elsewhere**


### PR DESCRIPTION
`exit` is valid, `exit(42)` is valid, but `exit 42` is invalid. The optional expression must be surrounded by parenthesis.

See https://github.com/tagua-vm/parser/pull/73#issuecomment-259902148.