### PR TITLE
Simplify `print` rule

### DIFF
--- a/spec/10-expressions.md
+++ b/spec/10-expressions.md
@@ -688,7 +688,6 @@ list(0 => list($x1, $x2), 1 => list($x2, $y2)) = [[1, 2], [3, 4]];
 <pre>
   <i>print-intrinsic:</i>
     print  <i>expression</i>
-    print  (  <i>expression</i>  )
 </pre>
 
 **Defined elsewhere**


### PR DESCRIPTION
`print 42` is the same than `print(42)`, which is the same than `print (42)`. Just like `echo`, it is possible to consider that parenthesis belong to the expression instead of to the `print` intrinsic.