### PR TITLE
Reflect changes for RFC: Deprecate and Remove Bareword (Unquoted) Strings

### DIFF
--- a/spec/07-variables.md
+++ b/spec/07-variables.md
@@ -52,7 +52,7 @@ and is a non-modifiable lvalue.
 
 Undefined constants are not defined implicitly -- forward usages of constants are also classified as undefined constants here. A distinction between class/interface constants and top level constants is made.
 
-For top level constants: For unqualified usages, the name of the undefined constant (as string) is used as substitution value. Moreover, a notice is emitted stating that the corresponding constant was undefined. For qualified usages, an exception of type [`Error`](14-classes.md#class-error) is thrown.
+For top level constants: For unqualified usages, the name of the undefined constant (as string) is used as substitution value. Moreover, a warning is emitted stating that the corresponding constant was undefined. For qualified usages, an exception of type [`Error`](14-classes.md#class-error) is thrown.
 
 For class/interface constants: An exception of type [`Error`](14-classes.md#class-error) is thrown, stating that the corresponding constant was undefined.
 
@@ -66,18 +66,18 @@ define('FAILURE', TRUE);
 
 // Examples of undefined constants
 echo NON_EXISTING_CONSTANT;     // uses 'NON_EXISTING_CONSTANT' as substitution
-                                // value and emits a notice stating that the
+                                // value and emits a warning stating that the
                                 // constant was undefined.
 
 echo NON_EXISTING_CONSTANT;     // same here, the constant is still undefined 
                                 // and 'NON_EXISTING_CONSTANT' is used as 
-                                // substitution value and a notice is emitted 
+                                // substitution value and a warning is emitted 
                                 // again.
 
 echo MAX_LENGTH;                // same here due to a forward usage 
                                 // (MAX_LENGTH is defined further below).
                                 // 'MAX_LENGTH' is used as substitution 
-                                // value and an notice is emitted.
+                                // value and a warning is emitted.
 
 echo \NON_EXISTING_CONSTANT;    // qualified use of undefined constant. Throws
                                 // an exception of type Error.

--- a/spec/10-expressions.md
+++ b/spec/10-expressions.md
@@ -3540,7 +3540,7 @@ class Bar{
     include 'include.php';
   }
 }
-echo X;                // emits a notice: Use of undefined constant X ...
+echo X;                // emits a warning: Use of undefined constant X ...
 echo \foo\X;           // same as above since the inclusion did not happen yet
 $bar = new Bar();
 $bar->bar();

--- a/tests/functions/basics.phpt
+++ b/tests/functions/basics.phpt
@@ -82,12 +82,12 @@ echo strlen("abcedfg")."\n";
 f1: # arguments passed is 0
 NULL
 
-Notice: Use of undefined constant f1 - assumed 'f1' in %s/functions/basics.php on line 30
+Warning: Use of undefined constant f1 - assumed 'f1' (this will throw an error in a future version of PHP) in %s/functions/basics.php on line 30
 
-Notice: Use of undefined constant f1 - assumed 'f1' in %s/functions/basics.php on line 31
+Warning: Use of undefined constant f1 - assumed 'f1' (this will throw an error in a future version of PHP) in %s/functions/basics.php on line 31
 string(2) "f1"
 
-Notice: Use of undefined constant f1 - assumed 'f1' in %s/functions/basics.php on line 32
+Warning: Use of undefined constant f1 - assumed 'f1' (this will throw an error in a future version of PHP) in %s/functions/basics.php on line 32
 f1: # arguments passed is 0
 f1: # arguments passed is 0
 f1: # arguments passed is 1
@@ -107,7 +107,7 @@ f2: $p1 = 10, $p2 = 20
 f2: $p1 = 10, $p2 = 20
 5 squared = 25
 
-Notice: Use of undefined constant square - assumed 'square' in %s/functions/basics.php on line 74
+Warning: Use of undefined constant square - assumed 'square' (this will throw an error in a future version of PHP) in %s/functions/basics.php on line 74
 string(6) "square"
 float(5.29)
 7

--- a/tests/functions/basics.phpt
+++ b/tests/functions/basics.phpt
@@ -82,12 +82,12 @@ echo strlen("abcedfg")."\n";
 f1: # arguments passed is 0
 NULL
 
-Warning: Use of undefined constant f1 - assumed 'f1' (this will throw an error in a future version of PHP) in %s/functions/basics.php on line 30
+Warning: Use of undefined constant f1 - assumed 'f1' (this will throw an Error in a future version of PHP) in %s/functions/basics.php on line 30
 
-Warning: Use of undefined constant f1 - assumed 'f1' (this will throw an error in a future version of PHP) in %s/functions/basics.php on line 31
+Warning: Use of undefined constant f1 - assumed 'f1' (this will throw an Error in a future version of PHP) in %s/functions/basics.php on line 31
 string(2) "f1"
 
-Warning: Use of undefined constant f1 - assumed 'f1' (this will throw an error in a future version of PHP) in %s/functions/basics.php on line 32
+Warning: Use of undefined constant f1 - assumed 'f1' (this will throw an Error in a future version of PHP) in %s/functions/basics.php on line 32
 f1: # arguments passed is 0
 f1: # arguments passed is 0
 f1: # arguments passed is 1
@@ -107,7 +107,7 @@ f2: $p1 = 10, $p2 = 20
 f2: $p1 = 10, $p2 = 20
 5 squared = 25
 
-Warning: Use of undefined constant square - assumed 'square' (this will throw an error in a future version of PHP) in %s/functions/basics.php on line 74
+Warning: Use of undefined constant square - assumed 'square' (this will throw an Error in a future version of PHP) in %s/functions/basics.php on line 74
 string(6) "square"
 float(5.29)
 7

--- a/tests/functions/order_of_evaluation.phpt
+++ b/tests/functions/order_of_evaluation.phpt
@@ -53,11 +53,11 @@ $funcTable[$i++]($i, ++$i, $i, $i = 12, --$i);	// function designator side effec
 --EXPECTF--
 f: $p1 = 0, $p2 = 1, $p3 = 1, $p4 = 12, $p5 = 11
 
-Notice: Use of undefined constant f - assumed 'f' in %s/functions/order_of_evaluation.php on line 34
+Warning: Use of undefined constant f - assumed 'f' (this will throw an error in a future version of PHP) in %s/functions/order_of_evaluation.php on line 34
 
-Notice: Use of undefined constant g - assumed 'g' in %s/functions/order_of_evaluation.php on line 34
+Warning: Use of undefined constant g - assumed 'g' (this will throw an error in a future version of PHP) in %s/functions/order_of_evaluation.php on line 34
 
-Notice: Use of undefined constant h - assumed 'h' in %s/functions/order_of_evaluation.php on line 34
+Warning: Use of undefined constant h - assumed 'h' (this will throw an error in a future version of PHP) in %s/functions/order_of_evaluation.php on line 34
 array(3) {
   [0]=>
   string(1) "f"

--- a/tests/functions/order_of_evaluation.phpt
+++ b/tests/functions/order_of_evaluation.phpt
@@ -53,11 +53,11 @@ $funcTable[$i++]($i, ++$i, $i, $i = 12, --$i);	// function designator side effec
 --EXPECTF--
 f: $p1 = 0, $p2 = 1, $p3 = 1, $p4 = 12, $p5 = 11
 
-Warning: Use of undefined constant f - assumed 'f' (this will throw an error in a future version of PHP) in %s/functions/order_of_evaluation.php on line 34
+Warning: Use of undefined constant f - assumed 'f' (this will throw an Error in a future version of PHP) in %s/functions/order_of_evaluation.php on line 34
 
-Warning: Use of undefined constant g - assumed 'g' (this will throw an error in a future version of PHP) in %s/functions/order_of_evaluation.php on line 34
+Warning: Use of undefined constant g - assumed 'g' (this will throw an Error in a future version of PHP) in %s/functions/order_of_evaluation.php on line 34
 
-Warning: Use of undefined constant h - assumed 'h' (this will throw an error in a future version of PHP) in %s/functions/order_of_evaluation.php on line 34
+Warning: Use of undefined constant h - assumed 'h' (this will throw an Error in a future version of PHP) in %s/functions/order_of_evaluation.php on line 34
 array(3) {
   [0]=>
   string(1) "f"

--- a/tests/variables/variable_names.phpt
+++ b/tests/variables/variable_names.phpt
@@ -54,7 +54,7 @@ int(99)
 int(100)
 int(101)
 
-Warning: Use of undefined constant total - assumed 'total' (this will throw an error in a future version of PHP) in %s/variables/variable_names.php on line 25
+Warning: Use of undefined constant total - assumed 'total' (this will throw an Error in a future version of PHP) in %s/variables/variable_names.php on line 25
 array(12) {
   ["argc"]=>
   int(1)

--- a/tests/variables/variable_names.phpt
+++ b/tests/variables/variable_names.phpt
@@ -54,7 +54,7 @@ int(99)
 int(100)
 int(101)
 
-Notice: Use of undefined constant total - assumed 'total' in %s/variables/variable_names.php on line 25
+Warning: Use of undefined constant total - assumed 'total' (this will throw an error in a future version of PHP) in %s/variables/variable_names.php on line 25
 array(12) {
   ["argc"]=>
   int(1)


### PR DESCRIPTION
This reflects the current implementation for my RFC, currently Under Discussion at https://wiki.php.net/rfc/deprecate-bareword-strings

The corresponding php-src PR is here: https://github.com/php/php-src/pull/2404