### PR TITLE
Fix grammar for breakout-level

### DIFF
--- a/spec/11-statements.md
+++ b/spec/11-statements.md
@@ -831,6 +831,7 @@ continue-statement:
 
 breakout-level:
   integer-literal
+  ( integer-literal )
 -->
 
 <pre>
@@ -839,6 +840,7 @@ breakout-level:
 
 <i id="grammar-breakout-level">breakout-level:</i>
    <i><a href="09-lexical-structure.md#grammar-integer-literal">integer-literal</a></i>
+   (   <i><a href="09-lexical-structure.md#grammar-integer-literal">integer-literal</a></i>   )
 </pre>
 
 **Constraints**

--- a/spec/11-statements.md
+++ b/spec/11-statements.md
@@ -840,7 +840,7 @@ breakout-level:
 
 <i id="grammar-breakout-level">breakout-level:</i>
    <i><a href="09-lexical-structure.md#grammar-integer-literal">integer-literal</a></i>
-   (   <i><a href="09-lexical-structure.md#grammar-integer-literal">integer-literal</a></i>   )
+   (   <i><a href="#grammar-breakout-level">breakout-level</a></i>   )
 </pre>
 
 **Constraints**

--- a/spec/11-statements.md
+++ b/spec/11-statements.md
@@ -831,7 +831,7 @@ continue-statement:
 
 breakout-level:
   integer-literal
-  ( integer-literal )
+  '(' breakout-level ')'
 -->
 
 <pre>

--- a/spec/19-grammar.md
+++ b/spec/19-grammar.md
@@ -849,7 +849,7 @@ The grammar notation is described in [Grammars section](09-lexical-structure.md#
 
 <i id="grammar-breakout-level">breakout-level:</i>
    <i><a href="#grammar-integer-literal">integer-literal</a></i>
-   <i>(   <a href="#grammar-integer-literal">integer-literal</a>   )</i>
+   (   <i><a href="#grammar-breakout-level">breakout-level</a></i>   )
 
 <i id="grammar-break-statement">break-statement:</i>
    break   <i><a href="#grammar-breakout-level">breakout-level</a></i><sub>opt</sub>   ;

--- a/spec/19-grammar.md
+++ b/spec/19-grammar.md
@@ -849,6 +849,7 @@ The grammar notation is described in [Grammars section](09-lexical-structure.md#
 
 <i id="grammar-breakout-level">breakout-level:</i>
    <i><a href="#grammar-integer-literal">integer-literal</a></i>
+   <i>(   <a href="#grammar-integer-literal">integer-literal</a>   )</i>
 
 <i id="grammar-break-statement">break-statement:</i>
    break   <i><a href="#grammar-breakout-level">breakout-level</a></i><sub>opt</sub>   ;


### PR DESCRIPTION
The optional breakout-level constant for `break` and `continue` statements can also be enclosed in parentheses.