### PR TITLE
Fixes #217: Incorrect rule for `trait-select-insteadof-clause`

### DIFF
--- a/spec/16-traits.md
+++ b/spec/16-traits.md
@@ -139,7 +139,7 @@ trait-select-and-alias-clause:
   trait-alias-as-clause ';'
 
 trait-select-insteadof-clause:
-  name 'insteadof' name
+  qualified-name '::' name 'insteadof' trait-name-list
 
 trait-alias-as-clause:
   name 'as' visibility-modifier? name
@@ -171,7 +171,7 @@ trait-alias-as-clause:
    <i><a href="#grammar-trait-alias-as-clause">trait-alias-as-clause</a></i>   ;
 
 <i id="grammar-trait-select-insteadof-clause">trait-select-insteadof-clause:</i>
-   <i><a href="09-lexical-structure.md#grammar-name">name</a></i>   insteadof   <i><a href="09-lexical-structure.md#grammar-name">name</a></i>
+   <i><a href="09-lexical-structure.md#grammar-qualified-name">qualified-name</a></i>   ::   <i><a href="09-lexical-structure.md#grammar-name">name</a></i>   insteadof   <i><a href="#grammar-trait-name-list">trait-name-list</a></i>
 
 <i id="grammar-trait-alias-as-clause">trait-alias-as-clause:</i>
    <i><a href="09-lexical-structure.md#grammar-name">name</a></i>   as   <i><a href="14-classes.md#grammar-visibility-modifier">visibility-modifier</a></i><sub>opt</sub>   <i><a href="09-lexical-structure.md#grammar-name">name</a></i>

--- a/spec/19-grammar.md
+++ b/spec/19-grammar.md
@@ -1095,7 +1095,7 @@ The grammar notation is described in [Grammars section](09-lexical-structure.md#
    <i><a href="#grammar-trait-alias-as-clause">trait-alias-as-clause</a></i>   ;
 
 <i id="grammar-trait-select-insteadof-clause">trait-select-insteadof-clause:</i>
-   <i><a href="#grammar-name">name</a></i>   insteadof   <i><a href="#grammar-name">name</a></i>
+   <i><a href="#grammar-qualified-name">qualified-name</a></i>   ::   <i><a href="#grammar-name">name</a></i>   insteadof   <i><a href="#grammar-trait-name-list">trait-name-list</a></i>
 
 <i id="grammar-trait-alias-as-clause">trait-alias-as-clause:</i>
    <i><a href="#grammar-name">name</a></i>   as   <i><a href="#grammar-visibility-modifier">visibility-modifier</a></i><sub>opt</sub>   <i><a href="#grammar-name">name</a></i>


### PR DESCRIPTION
An example of the insteadof clause (satisfies the fixed rule):

`use T1,T2,T3{T1::foo insteadof T2,T3;}`