### PR TITLE
fix(constants): remove duplicate E_USER_DEPRECATED def

### DIFF
--- a/spec/06-constants.md
+++ b/spec/06-constants.md
@@ -73,7 +73,6 @@ Constant Name | Description
 `E_USER_NOTICE` | `int`; User-generated warning message. This is like an `E_NOTICE`, except that `E_USER_NOTICE` is generated in PHP code by using the library function [`trigger_error`](http://www.php.net/trigger_error).
 `E_USER_WARNING` |  `int`; User-generated warning message. This is like an `E_WARNING`, except that  `E_USER_WARNING` is generated in PHP code by using the library function [`trigger_error`](http://www.php.net/trigger_error).
 `E_WARNING` | `int`; Run-time warnings (non-fatal errors). Execution of the script is not halted.
-`E_USER_DEPRECATED` | `int`; User-generated warning message. This is like an `E_DEPRECATED`, except that `E_USER_DEPRECATED` is generated in PHP code by using the library function [`trigger_error`](http://www.php.net/trigger_error).
 `FALSE` |   `bool`; the case-insensitive Boolean value `FALSE`.
 `INF` | `float`; Infinity
 `M_1_PI` |  `float`; 1/pi


### PR DESCRIPTION
`E_USER_DEPRECATED` is already defined on line 71. https://github.com/php/php-langspec/compare/master...sno2:php-langspec:patch-1#diff-2845c22189db836ad3de9b518ddf08252804a71b98c3f0405de88afda6daf6c8L71