### PR TITLE
Add grammar for `readonly` class modifier

### DIFF
--- a/spec/14-classes.md
+++ b/spec/14-classes.md
@@ -60,11 +60,16 @@ While PHP supports *anonymous class types*, such a type cannot be declared using
 
 <!-- GRAMMAR
 class-declaration:
-  class-modifier? 'class' name class-base-clause? class-interface-clause? '{' class-member-declarations? '}'
+  class-modifiers? 'class' name class-base-clause? class-interface-clause? '{' class-member-declarations? '}'
+
+class-modifiers:
+  class-modifier
+  class-modifiers class-modifier
 
 class-modifier:
   'abstract'
   'final'
+  'readonly'
 
 class-base-clause:
   'extends' qualified-name
@@ -76,11 +81,16 @@ class-interface-clause:
 
 <pre>
 <i id="grammar-class-declaration">class-declaration:</i>
-   <i><a href="#grammar-class-modifier">class-modifier</a></i><sub>opt</sub>   class   <i><a href="09-lexical-structure.md#grammar-name">name</a></i>   <i><a href="#grammar-class-base-clause">class-base-clause</a></i><sub>opt</sub>   <i><a href="#grammar-class-interface-clause">class-interface-clause</a></i><sub>opt</sub>   {   <i><a href="#grammar-class-member-declarations">class-member-declarations</a></i><sub>opt</sub>   }
+   <i><a href="#grammar-class-modifiers">class-modifiers</a></i><sub>opt</sub>   class   <i><a href="09-lexical-structure.md#grammar-name">name</a></i>   <i><a href="#grammar-class-base-clause">class-base-clause</a></i><sub>opt</sub>   <i><a href="#grammar-class-interface-clause">class-interface-clause</a></i><sub>opt</sub>   {   <i><a href="#grammar-class-member-declarations">class-member-declarations</a></i><sub>opt</sub>   }
+
+<i id="grammar-class-modifiers">class-modifiers:</i>
+   <i><a href="#grammar-class-modifier">class-modifier</a></i>
+   <i><a href="#grammar-class-modifiers">class-modifiers</a></i>   <i><a href="#grammar-class-modifier">class-modifier</a></i>
 
 <i id="grammar-class-modifier">class-modifier:</i>
    abstract
    final
+   readonly
 
 <i id="grammar-class-base-clause">class-base-clause:</i>
    extends   <i><a href="09-lexical-structure.md#grammar-qualified-name">qualified-name</a></i>

--- a/spec/19-grammar.md
+++ b/spec/19-grammar.md
@@ -964,11 +964,16 @@ The grammar notation is described in [Grammars section](09-lexical-structure.md#
 
 <pre>
 <i id="grammar-class-declaration">class-declaration:</i>
-   <i><a href="#grammar-class-modifier">class-modifier</a></i><sub>opt</sub>   class   <i><a href="#grammar-name">name</a></i>   <i><a href="#grammar-class-base-clause">class-base-clause</a></i><sub>opt</sub>   <i><a href="#grammar-class-interface-clause">class-interface-clause</a></i><sub>opt</sub>   {   <i><a href="#grammar-class-member-declarations">class-member-declarations</a></i><sub>opt</sub>   }
+   <i><a href="#grammar-class-modifiers">class-modifiers</a></i><sub>opt</sub>   class   <i><a href="#grammar-name">name</a></i>   <i><a href="#grammar-class-base-clause">class-base-clause</a></i><sub>opt</sub>   <i><a href="#grammar-class-interface-clause">class-interface-clause</a></i><sub>opt</sub>   {   <i><a href="#grammar-class-member-declarations">class-member-declarations</a></i><sub>opt</sub>   }
+
+<i id="grammar-class-modifiers">class-modifiers:</i>
+   <i><a href="#grammar-class-modifier">class-modifier</a></i>
+   <i><a href="#grammar-class-modifiers">class-modifiers</a></i>   <i><a href="#grammar-class-modifier">class-modifier</a></i>
 
 <i id="grammar-class-modifier">class-modifier:</i>
    abstract
    final
+   readonly
 
 <i id="grammar-class-base-clause">class-base-clause:</i>
    extends   <i><a href="#grammar-qualified-name">qualified-name</a></i>


### PR DESCRIPTION
This patch adds the grammar for `readonly` class modifier, via the following changes:

 - Update `spec/14-classes.md`
 - Execute `tools/pre-commit`

```diff
diff --git a/spec/14-classes.md b/spec/14-classes.md

--- a/spec/14-classes.md
+++ b/spec/14-classes.md

 class-declaration:
-  class-modifier? 'class' name class-base-clause? class-interface-clause? '{' class-member-declarations? '}'
+  class-modifiers? 'class' name class-base-clause? class-interface-clause? '{' class-member-declarations? '}'
+
+class-modifiers:
+  class-modifier
+  class-modifiers class-modifier
 
 class-modifier:
   'abstract'
   'final'
+  'readonly'
```