### PR TITLE
Add grammar for `readonly` property modifier

### DIFF
--- a/spec/14-classes.md
+++ b/spec/14-classes.md
@@ -489,8 +489,15 @@ property-declaration:
 
 property-modifier:
   'var'
-  visibility-modifier static-modifier?
-  static-modifier visibility-modifier?
+  visibility-modifier property-modifiers?
+  property-modifiers visibility-modifier?
+
+property-modifiers:
+  readonly-modifier
+  static-modifier
+
+readonly-modifier:
+  'readonly'
 
 visibility-modifier:
   'public'
@@ -517,8 +524,15 @@ property-initializer:
 
 <i id="grammar-property-modifier">property-modifier:</i>
    var
-   <i><a href="#grammar-visibility-modifier">visibility-modifier</a></i>   <i><a href="#grammar-static-modifier">static-modifier</a></i><sub>opt</sub>
-   <i><a href="#grammar-static-modifier">static-modifier</a></i>   <i><a href="#grammar-visibility-modifier">visibility-modifier</a></i><sub>opt</sub>
+   <i><a href="#grammar-visibility-modifier">visibility-modifier</a></i>   <i><a href="#grammar-property-modifiers">property-modifiers</a></i><sub>opt</sub>
+   <i><a href="#grammar-property-modifiers">property-modifiers</a></i>   <i><a href="#grammar-visibility-modifier">visibility-modifier</a></i><sub>opt</sub>
+
+<i id="grammar-property-modifiers">property-modifiers:</i>
+   <i><a href="#grammar-readonly-modifier">readonly-modifier</a></i>
+   <i><a href="#grammar-static-modifier">static-modifier</a></i>
+
+<i id="grammar-readonly-modifier">readonly-modifier:</i>
+   readonly
 
 <i id="grammar-visibility-modifier">visibility-modifier:</i>
    public

--- a/spec/19-grammar.md
+++ b/spec/19-grammar.md
@@ -1012,8 +1012,15 @@ The grammar notation is described in [Grammars section](09-lexical-structure.md#
 
 <i id="grammar-property-modifier">property-modifier:</i>
    var
-   <i><a href="#grammar-visibility-modifier">visibility-modifier</a></i>   <i><a href="#grammar-static-modifier">static-modifier</a></i><sub>opt</sub>
-   <i><a href="#grammar-static-modifier">static-modifier</a></i>   <i><a href="#grammar-visibility-modifier">visibility-modifier</a></i><sub>opt</sub>
+   <i><a href="#grammar-visibility-modifier">visibility-modifier</a></i>   <i><a href="#grammar-property-modifiers">property-modifiers</a></i><sub>opt</sub>
+   <i><a href="#grammar-property-modifiers">property-modifiers</a></i>   <i><a href="#grammar-visibility-modifier">visibility-modifier</a></i><sub>opt</sub>
+
+<i id="grammar-property-modifiers">property-modifiers:</i>
+   <i><a href="#grammar-readonly-modifier">readonly-modifier</a></i>
+   <i><a href="#grammar-static-modifier">static-modifier</a></i>
+
+<i id="grammar-readonly-modifier">readonly-modifier:</i>
+   readonly
 
 <i id="grammar-visibility-modifier">visibility-modifier:</i>
    public


### PR DESCRIPTION
This patch adds the grammar for `readonly` property modifier, via the following changes:

 - Update `spec/14-classes.md`
 - Execute `tools/pre-commit`

```diff
diff --git a/spec/14-classes.md b/spec/14-classes.md

--- a/spec/14-classes.md
+++ b/spec/14-classes.md

property-modifier:
  'var'
-  visibility-modifier static-modifier?
-  static-modifier visibility-modifier?
+  visibility-modifier property-modifiers?
+  property-modifiers visibility-modifier?
+
+property-modifiers:
+  readonly-modifier
+  static-modifier
+
+readonly-modifier:
+  'readonly'

visibility-modifier:
  'public'
```