### PR TITLE
"case-sensitive" and "case-insensitive" are easy to mix up

### DIFF
--- a/spec/06-constants.md
+++ b/spec/06-constants.md
@@ -27,14 +27,14 @@ string.
 ```PHP
 const MAX_HEIGHT = 10.5;              // define two (case-sensitive) c-constants
 const UPPER_LIMIT = MAX_HEIGHT;
-define('COEFFICIENT_1', 2.345, TRUE); // define a case-insensitive d-constant (deprecated)
+define('COEFFICIENT_1', 2.345, TRUE); // define a not case-sensitive d-constant (deprecated)
 define('FAILURE', FALSE, FALSE);      // define a case-sensitive d-constant
 ```
 
 ## Context-Dependent Constants
 
 The following constants—sometimes referred to as *magic constants*—are
-automatically available to all scripts; their values are not fixed and they are case-insensitive:
+automatically available to all scripts; their values are not fixed and they are not case-sensitive:
 
  Constant Name                    | Description
  -----------------                | ---------
@@ -73,7 +73,7 @@ Constant Name | Description
 `E_USER_NOTICE` | `int`; User-generated warning message. This is like an `E_NOTICE`, except that `E_USER_NOTICE` is generated in PHP code by using the library function [`trigger_error`](http://www.php.net/trigger_error).
 `E_USER_WARNING` |  `int`; User-generated warning message. This is like an `E_WARNING`, except that  `E_USER_WARNING` is generated in PHP code by using the library function [`trigger_error`](http://www.php.net/trigger_error).
 `E_WARNING` | `int`; Run-time warnings (non-fatal errors). Execution of the script is not halted.
-`FALSE` |   `bool`; the case-insensitive Boolean value `FALSE`.
+`FALSE` |   `bool`; the not case-sensitive Boolean value `FALSE`.
 `INF` | `float`; Infinity
 `M_1_PI` |  `float`; 1/pi
 `M_2_PI` |  `float`; 2/pi
@@ -93,7 +93,7 @@ Constant Name | Description
 `M_SQRT3` | `float`; sqrt(3)
 `M_SQRTPI` |  `float`; sqrt(pi)
 `NAN` | `float`; Not-a-Number
-`NULL` |  `null`; the case-insensitive value `NULL`.
+`NULL` |  `null`; the not case-sensitive value `NULL`.
 `PHP_BINARY` |  `string`; the PHP binary path during script execution.
 `PHP_BINDIR` |  `string`; the installation location of the binaries.
 `PHP_CONFIG_FILE_PATH` |  `string`; location from which php.ini values were parsed
@@ -130,7 +130,7 @@ Constant Name | Description
 `STDIN` | `resource`; File resource that maps to standard input (`php://stdin`).
 `STDOUT` | `resource`; File resource that maps to standard output (`php://stdout`).
 `STDERR` | `resource`; File resource that maps to standard error (`php://stderr`).
-`TRUE` |  `bool`; the case-insensitive Boolean value `TRUE`.
+`TRUE` |  `bool`; the not case-sensitive Boolean value `TRUE`.
 
 The members of the `E_*` family have values that are powers of 2, so
 they can be combined meaningfully using bitwise operators.

--- a/spec/14-classes.md
+++ b/spec/14-classes.md
@@ -140,7 +140,7 @@ Compatible arguments are defined as follows:
 **Semantics**
 
 A *class-declaration* defines a class type by the name *name*. Class
-names are case-insensitive.
+names are not case-sensitive.
 
 The `abstract` modifier declares a class usable only as a base class; the
 class cannot be instantiated directly. An abstract class may contain one
@@ -620,7 +620,7 @@ a function that is defined inside a class. However, the presence of
 is provided. The absence of `abstract` indicates a concrete method, in
 which case, an implementation is provided.
 
-Method names are case-insensitive.
+Method names are not case-sensitive.
 
 The presence of `final` indicates the method cannot be overridden in a
 derived class.

--- a/spec/15-interfaces.md
+++ b/spec/15-interfaces.md
@@ -47,7 +47,7 @@ Every *qualified-name* must name an interface type.
 An interface-declaration defines a contract that one or more classes can
 implement.
 
-Interface names are case-insensitive.
+Interface names are not case-sensitive.
 
 The optional *interface-base-clause* specifies the base interfaces from
 which the interface being defined is derived. In such a case, the

--- a/spec/16-traits.md
+++ b/spec/16-traits.md
@@ -79,7 +79,7 @@ trait-member-declaration:
 A *trait-declaration* defines a named set of members, which are made
 available to any class that uses that trait.
 
-Trait names are case-insensitive.
+Trait names are not case-sensitive.
 
 The members of a trait are those specified by its *trait-member-declaration*
 clauses, and members imported from any other traits using *trait-use-clauses*.

--- a/spec/18-namespaces.md
+++ b/spec/18-namespaces.md
@@ -75,7 +75,7 @@ Note that while definition has a short name, the name known to the engine
 is always the full name, and can be either specified as fully qualified name,
 composed from current namespace name and specified name, or [imported](#namespace-use-declarations).
 
-Namespace and sub-namespace names are case-insensitive.
+Namespace and sub-namespace names are not case-sensitive.
 
 The pre-defined constant [`__NAMESPACE__`](06-constants.md#context-dependent-constants) contains the name of
 the current namespace.

--- a/tests/lexical_structure/unicode_string_escape_sequence/unicode_escape.phpt
+++ b/tests/lexical_structure/unicode_string_escape_sequence/unicode_escape.phpt
@@ -5,7 +5,7 @@ PHP Spec test generated from ./lexical_structure/unicode_string_escape_sequence/
 
 var_dump("\u{61}"); // ASCII "a" - characters below U+007F just encode as ASCII, as it's UTF-8
 var_dump("\u{FF}"); // y with diaeresis
-var_dump("\u{ff}"); // case-insensitive
+var_dump("\u{ff}"); // not case-sensitive
 var_dump("\u{2603}"); // Unicode snowman
 var_dump("\u{1F602}"); // FACE WITH TEARS OF JOY emoji
 var_dump("\u{0000001F602}"); // Leading zeroes permitted


### PR DESCRIPTION
Replace "case-insensitive" with "not case-sensitive" so that it is not confused with "case-sensitive"

See issue #265 